### PR TITLE
Add Netlify MongoDB functions and guest record flow

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,23 @@
   for = "/assets/*"
   [headers.values]
     Cache-Control = "public, max-age=2628000, immutable"
+
+[[redirects]]
+  from = "/api/count"
+  to = "/.netlify/functions/count"
+  status = 200
+
+[[redirects]]
+  from = "/api/streak"
+  to = "/.netlify/functions/streak"
+  status = 200
+
+[[redirects]]
+  from = "/api/history"
+  to = "/.netlify/functions/history"
+  status = 200
+
+[[redirects]]
+  from = "/api/leaderboard"
+  to = "/.netlify/functions/leaderboard"
+  status = 200

--- a/netlify/functions/_lib/http.js
+++ b/netlify/functions/_lib/http.js
@@ -1,0 +1,34 @@
+const commonHeaders = {
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store",
+};
+
+/**
+ * Build a JSON response for Netlify Functions.
+ */
+function json(statusCode, body) {
+  return {
+    statusCode,
+    headers: commonHeaders,
+    body: JSON.stringify(body),
+  };
+}
+
+/**
+ * Parse JSON body safely and return null on parse failure.
+ */
+function parseBody(rawBody) {
+  if (!rawBody) {
+    return {};
+  }
+  try {
+    return JSON.parse(rawBody);
+  } catch (error) {
+    return null;
+  }
+}
+
+module.exports = {
+  json,
+  parseBody,
+};

--- a/netlify/functions/_lib/mongo.js
+++ b/netlify/functions/_lib/mongo.js
@@ -1,0 +1,34 @@
+const { MongoClient } = require("mongodb");
+
+let cachedClient = null;
+let cachedDb = null;
+
+/**
+ * Return a shared MongoDB database instance for Netlify Function invocations.
+ */
+async function getDb() {
+  if (cachedDb) {
+    return cachedDb;
+  }
+
+  const uri = process.env.MONGODB_URI;
+  const dbName = process.env.MONGODB_DB_NAME || "yakemon";
+
+  if (!uri) {
+    throw new Error("MONGODB_URI is not configured");
+  }
+
+  if (!cachedClient) {
+    cachedClient = new MongoClient(uri, {
+      maxPoolSize: 5,
+    });
+  }
+
+  await cachedClient.connect();
+  cachedDb = cachedClient.db(dbName);
+  return cachedDb;
+}
+
+module.exports = {
+  getDb,
+};

--- a/netlify/functions/_lib/player.js
+++ b/netlify/functions/_lib/player.js
@@ -1,0 +1,49 @@
+/**
+ * Sanitize and normalize player id from client payload.
+ */
+function normalizePlayerId(playerId) {
+  if (!playerId || typeof playerId !== "string") {
+    return "";
+  }
+  return playerId.trim().slice(0, 120);
+}
+
+/**
+ * Build a fallback display name from the player id.
+ */
+function buildDefaultName(playerId) {
+  const suffix = playerId.slice(-6).toUpperCase();
+  return `Trainer-${suffix}`;
+}
+
+/**
+ * Ensure a player document exists and return the upserted player.
+ */
+async function ensurePlayer(playersCollection, playerId) {
+  const now = new Date();
+  await playersCollection.updateOne(
+    { playerId },
+    {
+      $setOnInsert: {
+        playerId,
+        displayName: buildDefaultName(playerId),
+        winCount: 0,
+        loseCount: 0,
+        winStreak: 0,
+        bestWinStreak: 0,
+        createdAt: now,
+      },
+      $set: {
+        updatedAt: now,
+      },
+    },
+    { upsert: true }
+  );
+
+  return playersCollection.findOne({ playerId });
+}
+
+module.exports = {
+  normalizePlayerId,
+  ensurePlayer,
+};

--- a/netlify/functions/count.js
+++ b/netlify/functions/count.js
@@ -1,0 +1,65 @@
+const { getDb } = require("./_lib/mongo");
+const { json, parseBody } = require("./_lib/http");
+const { normalizePlayerId, ensurePlayer } = require("./_lib/player");
+
+/**
+ * Update win/lose counts and return the latest aggregate stats.
+ */
+exports.handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return json(405, { message: "Method not allowed" });
+  }
+
+  const body = parseBody(event.body);
+  if (!body) {
+    return json(400, { message: "Invalid JSON body" });
+  }
+
+  const playerId = normalizePlayerId(body.playerId);
+  const result = body.result;
+
+  if (!playerId) {
+    return json(400, { message: "playerId is required" });
+  }
+
+  if (result !== "win" && result !== "lose") {
+    return json(400, { message: "result must be win or lose" });
+  }
+
+  try {
+    const db = await getDb();
+    const players = db.collection("players");
+    const current = await ensurePlayer(players, playerId);
+    const now = new Date();
+
+    const nextWinCount = (current.winCount || 0) + (result === "win" ? 1 : 0);
+    const nextLoseCount = (current.loseCount || 0) + (result === "lose" ? 1 : 0);
+    const nextWinStreak = result === "win" ? (current.winStreak || 0) + 1 : 0;
+    const nextBestWinStreak = Math.max(current.bestWinStreak || 0, nextWinStreak);
+
+    await players.updateOne(
+      { playerId },
+      {
+        $set: {
+          winCount: nextWinCount,
+          loseCount: nextLoseCount,
+          winStreak: nextWinStreak,
+          bestWinStreak: nextBestWinStreak,
+          lastResult: result,
+          updatedAt: now,
+        },
+      }
+    );
+
+    return json(200, {
+      playerId,
+      winCount: nextWinCount,
+      loseCount: nextLoseCount,
+      winStreak: nextWinStreak,
+      bestWinStreak: nextBestWinStreak,
+    });
+  } catch (error) {
+    console.error("[count] failed", error);
+    return json(500, { message: "Failed to update counts" });
+  }
+};

--- a/netlify/functions/history.js
+++ b/netlify/functions/history.js
@@ -1,0 +1,46 @@
+const { getDb } = require("./_lib/mongo");
+const { json, parseBody } = require("./_lib/http");
+const { normalizePlayerId } = require("./_lib/player");
+
+/**
+ * Append one battle history event.
+ */
+exports.handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return json(405, { message: "Method not allowed" });
+  }
+
+  const body = parseBody(event.body);
+  if (!body) {
+    return json(400, { message: "Invalid JSON body" });
+  }
+
+  const playerId = normalizePlayerId(body.playerId);
+  const result = body.result;
+  const mode = typeof body.mode === "string" ? body.mode.slice(0, 40) : "normal";
+
+  if (!playerId) {
+    return json(400, { message: "playerId is required" });
+  }
+
+  if (result !== "win" && result !== "lose") {
+    return json(400, { message: "result must be win or lose" });
+  }
+
+  try {
+    const db = await getDb();
+    const history = db.collection("play_history");
+
+    await history.insertOne({
+      playerId,
+      result,
+      mode,
+      createdAt: new Date(),
+    });
+
+    return json(201, { ok: true });
+  } catch (error) {
+    console.error("[history] failed", error);
+    return json(500, { message: "Failed to save history" });
+  }
+};

--- a/netlify/functions/leaderboard.js
+++ b/netlify/functions/leaderboard.js
@@ -1,0 +1,36 @@
+const { getDb } = require("./_lib/mongo");
+const { json } = require("./_lib/http");
+
+/**
+ * Return top player rankings by best win streak.
+ */
+exports.handler = async (event) => {
+  if (event.httpMethod !== "GET") {
+    return json(405, { message: "Method not allowed" });
+  }
+
+  try {
+    const db = await getDb();
+    const players = db.collection("players");
+    const docs = await players
+      .find({})
+      .sort({ bestWinStreak: -1, winStreak: -1, updatedAt: 1 })
+      .limit(50)
+      .toArray();
+
+    const payload = docs.map((doc, index) => ({
+      rank: index + 1,
+      playerId: doc.playerId,
+      username: doc.displayName || `Trainer-${String(doc.playerId || "").slice(-6).toUpperCase()}`,
+      winStreak: doc.winStreak || 0,
+      bestWinStreak: doc.bestWinStreak || 0,
+      winCount: doc.winCount || 0,
+      loseCount: doc.loseCount || 0,
+    }));
+
+    return json(200, payload);
+  } catch (error) {
+    console.error("[leaderboard] failed", error);
+    return json(500, { message: "Failed to load leaderboard" });
+  }
+};

--- a/netlify/functions/streak.js
+++ b/netlify/functions/streak.js
@@ -1,0 +1,65 @@
+const { getDb } = require("./_lib/mongo");
+const { json, parseBody } = require("./_lib/http");
+const { normalizePlayerId, ensurePlayer } = require("./_lib/player");
+
+/**
+ * Update win streak-centric result and return current stats.
+ */
+exports.handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return json(405, { message: "Method not allowed" });
+  }
+
+  const body = parseBody(event.body);
+  if (!body) {
+    return json(400, { message: "Invalid JSON body" });
+  }
+
+  const playerId = normalizePlayerId(body.playerId);
+  const result = body.result;
+
+  if (!playerId) {
+    return json(400, { message: "playerId is required" });
+  }
+
+  if (result !== "win" && result !== "lose") {
+    return json(400, { message: "result must be win or lose" });
+  }
+
+  try {
+    const db = await getDb();
+    const players = db.collection("players");
+    const current = await ensurePlayer(players, playerId);
+    const now = new Date();
+
+    const nextWinCount = (current.winCount || 0) + (result === "win" ? 1 : 0);
+    const nextLoseCount = (current.loseCount || 0) + (result === "lose" ? 1 : 0);
+    const nextWinStreak = result === "win" ? (current.winStreak || 0) + 1 : 0;
+    const nextBestWinStreak = Math.max(current.bestWinStreak || 0, nextWinStreak);
+
+    await players.updateOne(
+      { playerId },
+      {
+        $set: {
+          winCount: nextWinCount,
+          loseCount: nextLoseCount,
+          winStreak: nextWinStreak,
+          bestWinStreak: nextBestWinStreak,
+          lastResult: result,
+          updatedAt: now,
+        },
+      }
+    );
+
+    return json(200, {
+      playerId,
+      winCount: nextWinCount,
+      loseCount: nextLoseCount,
+      winStreak: nextWinStreak,
+      bestWinStreak: nextBestWinStreak,
+    });
+  } catch (error) {
+    console.error("[streak] failed", error);
+    return json(500, { message: "Failed to update streak" });
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tensorflow/tfjs": "^4.9.0",
         "axios": "^1.9.0",
+        "mongodb": "^6.21.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router-dom": "^7.5.0",
@@ -736,6 +737,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
+      "integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@tensorflow/tfjs": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-4.9.0.tgz",
@@ -928,6 +938,21 @@
       "integrity": "sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==",
       "license": "MIT"
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-3.1.0.tgz",
@@ -1035,6 +1060,15 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1584,6 +1618,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -1603,6 +1643,96 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
+      "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ms": {
@@ -1699,6 +1829,15 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -1866,6 +2005,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@tensorflow/tfjs": "^4.9.0",
     "axios": "^1.9.0",
+    "mongodb": "^6.21.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^7.5.0",

--- a/readme.md
+++ b/readme.md
@@ -5,3 +5,21 @@
 - npm install로 의존성을 설치해주세요. 처음 할 때는 좀 시간이 걸립니다.
 - npm run dev를 실행하시면 로컬 5173 포트에 개발환경이 실행됩니다.
 - http://localhost:5173/ 로 접속하시면 화면이 보입니다.
+
+## MongoDB + Netlify Functions 전적 저장
+
+- 전적/리더보드는 Netlify Functions를 통해 MongoDB Atlas에 저장됩니다.
+- 프론트에서 DB 직접 연결은 하지 않습니다.
+
+### Netlify 환경변수
+
+- `MONGODB_URI`: MongoDB Atlas connection string
+- `MONGODB_DB_NAME`: 사용할 DB 이름 (예: `yakemon`)
+
+### API 라우팅
+
+- 아래 경로는 Netlify에서 Functions로 리다이렉트됩니다.
+  - `/api/count` -> `/.netlify/functions/count`
+  - `/api/streak` -> `/.netlify/functions/streak`
+  - `/api/history` -> `/.netlify/functions/history`
+  - `/api/leaderboard` -> `/.netlify/functions/leaderboard`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,36 +8,23 @@ import "./index.css";
 import { createBattlePokemon } from "./utils/battleLogics/createBattlePokemon";
 import { useBattleStore } from "./Context/useBattleStore";
 import { PokemonInfo } from "./models/Pokemon";
-import { createMockPokemon } from "./data/mockPokemon";
-import { applyAppearance } from "./utils/battleLogics/applyAppearance";
 import { BattlePokemon } from "./models/BattlePokemon";
 import BottomBar from "./components/BottomBar";
-import { Route, BrowserRouter as Router, Routes, useNavigate } from "react-router-dom";
+import { Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { shuffleArray } from "./utils/shuffle";
-import { createGen1Pokemon, createGen2Pokemon, createGen3Pokemon, createGen4Pokemon, createGen5Pokemon, createGen6Pokemon, createGen7Pokemon, createGen8Pokemon, createGen9Pokemon } from "./data/createWincountPokemon";
-
-const gen1Pokemon = createGen1Pokemon();
-const gen2Pokemon = gen1Pokemon.concat(createGen2Pokemon());
-const gen3Pokemon = gen2Pokemon.concat(createGen3Pokemon());
-const gen4Pokemon = gen3Pokemon.concat(createGen4Pokemon());
-const gen5Pokemon = gen4Pokemon.concat(createGen5Pokemon());
-const gen6Pokemon = gen5Pokemon.concat(createGen6Pokemon());
-const gen7Pokemon = gen6Pokemon.concat(createGen7Pokemon());
-const gen8Pokemon = gen7Pokemon.concat(createGen8Pokemon());
-const gen9Pokemon = gen8Pokemon.concat(createGen9Pokemon());
+import { createGen1Pokemon } from "./data/createWincountPokemon";
 
 function MainApp() {
   const mockPokemon = createGen1Pokemon();
-  const [isSelected, setIsSelected] = useState(false);
   const { setMyTeam, setEnemyTeam } = useBattleStore();
   const [watchMode, setWatchMode] = useState(false);
   const [redMode, setRedMode] = useState(false);
   const [randomeMode, setRandomMode] = useState(false);
   const [watchCount, setWatchCount] = useState(1);
   const [watchDelay, setWatchDelay] = useState(1.5);
-  const { addLog } = useBattleStore.getState();
   const [battleKey, setBattleKey] = useState(0);
   const navigate = useNavigate();
+  const location = useLocation();
 
   const handleSelect = useCallback(
     (playerPokemons: PokemonInfo[], watchMode: boolean, redMode: boolean, randomMode: boolean, watchCount?: number, watchDelay?: number) => {
@@ -94,7 +81,6 @@ function MainApp() {
       navigate("/battle");
       setMyTeam(myBattleTeam);
       setEnemyTeam(aiBattleTeam);
-      setIsSelected(true); // 화면 전환 트리거
     },
     [setMyTeam, setEnemyTeam]
   );
@@ -118,17 +104,13 @@ function MainApp() {
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/leaderboard" element={<Leaderboard />} />
       </Routes>
+      {location.pathname !== "/battle" && <BottomBar />}
     </>
   );
 }
 
 function App() {
-  return (
-    <>
-      <MainApp />
-      <BottomBar />
-    </>
-  );
+  return <MainApp />;
 }
 
 export default App;

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -2,16 +2,16 @@ import { request } from '../utils/request';
 import { AuthResponse, LoginRequest, RegisterRequest, User } from '../types/user';
 
 export const login = async (data: LoginRequest): Promise<AuthResponse> => {
-  const response = await request.post<AuthResponse>('/api/auth/login', data);
+  const response = await request.post<AuthResponse>('/auth/login', data);
   return response.data;
 };
 
 export const register = async (data: RegisterRequest): Promise<AuthResponse> => {
-  const response = await request.post<AuthResponse>('/api/auth/register', data);
+  const response = await request.post<AuthResponse>('/auth/register', data);
   return response.data;
 };
 
 export const getProfile = async (): Promise<User> => {
-  const response = await request.get<User>('/api/auth/profile');
+  const response = await request.get<User>('/auth/profile');
   return response.data;
 }; 

--- a/src/api/leaderboard.ts
+++ b/src/api/leaderboard.ts
@@ -5,15 +5,27 @@ export interface LeaderboardEntry {
   rank: number;
   username: string;
   streak: number;
-  wins: number;
+}
+
+export class LeaderboardError extends Error {
+  constructor(message: string, public status?: number) {
+    super(message);
+    this.name = 'LeaderboardError';
+  }
 }
 
 export const getLeaderboard = async (): Promise<LeaderboardEntry[]> => {
-  const response = await request.get<User[]>('/api/leaderboard');
-  return response.data.map((user, index) => ({
-    rank: index + 1,
-    username: user.username,
-    streak: user.winStreak,
-    wins: user.winCount,
-  }));
+  try {
+    const response = await request.get<User[]>('/leaderboard');
+    return response.data.map((user, index) => ({
+      rank: index + 1,
+      username: user.username,
+      streak: user.winStreak,
+    }));
+  } catch (error: any) {
+    if (error.response?.status === 400) {
+      throw new LeaderboardError('리더보드를 불러오는데 실패했습니다.');
+    }
+    throw new LeaderboardError('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+  }
 }; 

--- a/src/api/leaderboard.ts
+++ b/src/api/leaderboard.ts
@@ -1,5 +1,4 @@
-import { request } from '../utils/request';
-import { User } from '../types/user';
+import axios from "axios";
 
 export interface LeaderboardEntry {
   rank: number;
@@ -7,25 +6,34 @@ export interface LeaderboardEntry {
   streak: number;
 }
 
+interface LeaderboardResponseRow {
+  rank: number;
+  username: string;
+  winStreak: number;
+}
+
 export class LeaderboardError extends Error {
   constructor(message: string, public status?: number) {
     super(message);
-    this.name = 'LeaderboardError';
+    this.name = "LeaderboardError";
   }
 }
 
-export const getLeaderboard = async (): Promise<LeaderboardEntry[]> => {
+/**
+ * Fetch leaderboard rows from Netlify Functions and map them for UI.
+ */
+export async function getLeaderboard(): Promise<LeaderboardEntry[]> {
   try {
-    const response = await request.get<User[]>('/leaderboard');
-    return response.data.map((user, index) => ({
-      rank: index + 1,
-      username: user.username,
-      streak: user.winStreak,
+    const response = await axios.get<LeaderboardResponseRow[]>("/api/leaderboard");
+    return response.data.map((row) => ({
+      rank: row.rank,
+      username: row.username,
+      streak: row.winStreak,
     }));
   } catch (error: any) {
     if (error.response?.status === 400) {
-      throw new LeaderboardError('리더보드를 불러오는데 실패했습니다.');
+      throw new LeaderboardError("리더보드를 불러오는데 실패했습니다.", 400);
     }
-    throw new LeaderboardError('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+    throw new LeaderboardError("서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", error.response?.status);
   }
-}; 
+}

--- a/src/api/playhistory.ts
+++ b/src/api/playhistory.ts
@@ -1,56 +1,83 @@
-import { request } from '../utils/request';
-import { User } from '../types/user';
+import axios from "axios";
 
 export interface GameResult {
+  playerId: string;
   winCount: number;
   loseCount: number;
-  winStreak?: number;
+  winStreak: number;
+  bestWinStreak: number;
 }
 
 export class GameError extends Error {
   constructor(message: string, public status?: number) {
     super(message);
-    this.name = 'GameError';
+    this.name = "GameError";
   }
 }
 
-export const updateWinCount = async (result: 'win' | 'lose'): Promise<GameResult> => {
+const GUEST_PLAYER_KEY = "guestPlayerId";
+
+/**
+ * Return existing guest player id or create a new stable id for this browser.
+ */
+export function getOrCreateGuestPlayerId(): string {
+  const existing = localStorage.getItem(GUEST_PLAYER_KEY);
+  if (existing) {
+    return existing;
+  }
+
+  const generated = `guest_${crypto.randomUUID()}`;
+  localStorage.setItem(GUEST_PLAYER_KEY, generated);
+  return generated;
+}
+
+/**
+ * Send a result update to Netlify Functions and return updated aggregate values.
+ */
+async function postGameResult(path: string, result: "win" | "lose"): Promise<GameResult> {
+  const playerId = getOrCreateGuestPlayerId();
+
   try {
-    const response = await request.post<GameResult>('/count', { result });
+    const response = await axios.post<GameResult>(`/api${path}`, {
+      playerId,
+      result,
+    });
     return response.data;
   } catch (error: any) {
-    if (error.response?.status === 401) {
-      throw new GameError('로그인이 필요합니다.');
-    } else if (error.response?.status === 404) {
-      throw new GameError('사용자를 찾을 수 없습니다.');
+    if (error.response?.status === 400) {
+      throw new GameError("요청 값이 올바르지 않습니다.", 400);
     }
-    throw new GameError('승리/패배 기록 업데이트에 실패했습니다.');
+    throw new GameError("전적 저장에 실패했습니다.", error.response?.status);
   }
-};
+}
 
-export const updateWinStreak = async (result: 'win' | 'lose'): Promise<GameResult> => {
-  try {
-    const response = await request.post<GameResult>('/streak', { result });
-    return response.data;
-  } catch (error: any) {
-    if (error.response?.status === 401) {
-      throw new GameError('로그인이 필요합니다.');
-    } else if (error.response?.status === 404) {
-      throw new GameError('사용자를 찾을 수 없습니다.');
-    }
-    throw new GameError('연승 기록 업데이트에 실패했습니다.');
-  }
-};
+/**
+ * Update win/lose counts in the database.
+ */
+export async function updateWinCount(result: "win" | "lose"): Promise<GameResult> {
+  return postGameResult("/count", result);
+}
 
-export const addPlayHistory = async (result: 'win' | 'lose'): Promise<void> => {
+/**
+ * Update current win streak data in the database.
+ */
+export async function updateWinStreak(result: "win" | "lose"): Promise<GameResult> {
+  return postGameResult("/streak", result);
+}
+
+/**
+ * Append one play history record.
+ */
+export async function addPlayHistory(result: "win" | "lose", mode: "normal" | "random" = "normal"): Promise<void> {
+  const playerId = getOrCreateGuestPlayerId();
+
   try {
-    await request.post('/history', { result });
+    await axios.post("/api/history", {
+      playerId,
+      result,
+      mode,
+    });
   } catch (error: any) {
-    if (error.response?.status === 401) {
-      throw new GameError('로그인이 필요합니다.');
-    } else if (error.response?.status === 404) {
-      throw new GameError('사용자를 찾을 수 없습니다.');
-    }
-    throw new GameError('게임 기록 추가에 실패했습니다.');
+    throw new GameError("게임 히스토리 저장에 실패했습니다.", error.response?.status);
   }
-};
+}

--- a/src/components/ActionPanel.tsx
+++ b/src/components/ActionPanel.tsx
@@ -1,38 +1,226 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { BattlePokemon } from "../models/BattlePokemon";
 import SwapPanel from "./SwapPanel";
 import { useBattleStore } from "../Context/useBattleStore";
 import { calculateTypeEffectiveness } from "../utils/typeRalation";
+import { BattlePadAction } from "./BattlePad";
 
 type ActionPanelParams = {
-  myPokemon: BattlePokemon,
-  myTeam: BattlePokemon[],
-  activeMy: number,
-  isTurnProcessing: boolean,
+  myPokemon: BattlePokemon;
+  myTeam: BattlePokemon[];
+  activeMy: number;
+  isTurnProcessing: boolean;
   onAction: any;
   watchMode: boolean;
+  padCommand: { id: number; action: BattlePadAction } | null;
 };
 
-function ActionPanel({ myPokemon, myTeam, activeMy, isTurnProcessing, onAction, watchMode }: ActionPanelParams) {
+function ActionPanel({
+  myPokemon,
+  myTeam,
+  activeMy,
+  isTurnProcessing,
+  onAction,
+  watchMode,
+  padCommand,
+}: ActionPanelParams) {
   const isFainted = myPokemon.currentHp <= 0;
-
-  // ✅ 현재 모드: 'fight' | 'switch' | null (초기값은 null)
   const [currentTab, setCurrentTab] = useState<"fight" | "switch" | null>(null);
   const [hintMode, setHintMode] = useState<boolean>(true);
+  const [fightCursor, setFightCursor] = useState(0);
+  const [switchCursor, setSwitchCursor] = useState(0);
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 900);
   const { turn, enemyTeam, activeEnemy } = useBattleStore.getState();
   const enemyTypes = enemyTeam[activeEnemy].base.types;
+  const switchTargets = useMemo(
+    () => myTeam.map((pokemon, index) => ({ pokemon, index })).filter(({ pokemon, index }) => index !== activeMy && pokemon.currentHp > 0),
+    [activeMy, myTeam]
+  );
+
+  const getMoveDisabledState = useCallback(
+    (move: BattlePokemon["base"]["moves"][number]) =>
+      isTurnProcessing || isFainted || watchMode || myPokemon.unUsableMove?.name === move.name || myPokemon.pp[move.name] === 0,
+    [isFainted, isTurnProcessing, myPokemon.pp, myPokemon.unUsableMove?.name, watchMode]
+  );
+
   useEffect(() => {
     setCurrentTab(null);
-  }, [turn])
+    setFightCursor(0);
+    setSwitchCursor(0);
+  }, [turn]);
 
-  const isMobile = window.innerWidth <= 768;
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 900);
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  useEffect(() => {
+    if (switchCursor >= switchTargets.length) {
+      setSwitchCursor(0);
+    }
+  }, [switchCursor, switchTargets.length]);
+
+  const moveFightCursor = useCallback((direction: "up" | "down" | "left" | "right") => {
+    setFightCursor((prev) => {
+      const totalMoves = 4;
+      const row = Math.floor(prev / 2);
+      const col = prev % 2;
+
+      if (direction === "left") {
+        return row * 2 + ((col + 1) % 2);
+      }
+      if (direction === "right") {
+        return row * 2 + ((col + 1) % 2);
+      }
+      if (direction === "up") {
+        return ((row + 1) % 2) * 2 + col;
+      }
+      if (direction === "down") {
+        return ((row + 1) % 2) * 2 + col;
+      }
+      return prev % totalMoves;
+    });
+  }, []);
+
+  const moveSwitchCursor = useCallback((direction: "up" | "down" | "left" | "right") => {
+    if (switchTargets.length === 0) {
+      return;
+    }
+    setSwitchCursor((prev) => {
+      if (direction === "up" || direction === "left") {
+        return (prev - 1 + switchTargets.length) % switchTargets.length;
+      }
+      return (prev + 1) % switchTargets.length;
+    });
+  }, [switchTargets.length]);
+
+  const handlePadAction = useCallback(
+    (action: BattlePadAction) => {
+      if (action === "x") {
+        setHintMode((prev) => !prev);
+        return;
+      }
+
+      if (action === "y") {
+        if (myPokemon.status.includes("교체불가")) {
+          setCurrentTab("fight");
+          return;
+        }
+        setCurrentTab((prev) => (prev === "switch" ? "fight" : "switch"));
+        return;
+      }
+
+      if (action === "b") {
+        setCurrentTab(null);
+        return;
+      }
+
+      if (action === "up" || action === "down" || action === "left" || action === "right") {
+        if (!currentTab) {
+          setCurrentTab("fight");
+          return;
+        }
+        if (currentTab === "fight") {
+          moveFightCursor(action);
+          return;
+        }
+        moveSwitchCursor(action);
+        return;
+      }
+
+      if (action === "a") {
+        if (watchMode || isTurnProcessing) {
+          return;
+        }
+        if (!currentTab) {
+          setCurrentTab("fight");
+          return;
+        }
+        if (currentTab === "fight") {
+          const selectedMove = myPokemon.base.moves[fightCursor];
+          if (!selectedMove || getMoveDisabledState(selectedMove)) {
+            return;
+          }
+          onAction(selectedMove);
+          return;
+        }
+        const selectedSwitch = switchTargets[switchCursor];
+        if (selectedSwitch) {
+          onAction({ type: "switch", index: selectedSwitch.index });
+        }
+      }
+    },
+    [currentTab, fightCursor, getMoveDisabledState, isTurnProcessing, moveFightCursor, moveSwitchCursor, myPokemon.base.moves, myPokemon.status, onAction, switchCursor, switchTargets, watchMode]
+  );
+
+  useEffect(() => {
+    if (!padCommand) {
+      return;
+    }
+    handlePadAction(padCommand.action);
+  }, [handlePadAction, padCommand]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const targetElement = event.target as HTMLElement | null;
+      if (targetElement && ["INPUT", "TEXTAREA", "SELECT"].includes(targetElement.tagName)) {
+        return;
+      }
+
+      let mappedAction: BattlePadAction | null = null;
+      switch (event.code) {
+        case "ArrowUp":
+          mappedAction = "up";
+          break;
+        case "ArrowDown":
+          mappedAction = "down";
+          break;
+        case "ArrowLeft":
+          mappedAction = "left";
+          break;
+        case "ArrowRight":
+          mappedAction = "right";
+          break;
+        case "Enter":
+        case "Space":
+        case "KeyA":
+          mappedAction = "a";
+          break;
+        case "Escape":
+        case "Backspace":
+        case "KeyB":
+          mappedAction = "b";
+          break;
+        case "KeyX":
+          mappedAction = "x";
+          break;
+        case "KeyY":
+          mappedAction = "y";
+          break;
+        default:
+          break;
+      }
+
+      if (!mappedAction) {
+        return;
+      }
+      event.preventDefault();
+      handlePadAction(mappedAction);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handlePadAction]);
 
   return (
     <div className="action-panel">
       <button className="hint-toggle"
         onClick={() => setHintMode(!hintMode)}
       >타입 상성 힌트 모드 전환</button>
-      {/* 모바일 전용: 처음엔 싸운다/교체 버튼만 보여줌 */}
+      <div className="pad-help">방향키/D-Pad: 이동, A: 선택, B: 뒤로, X: 힌트, Y: 탭 전환</div>
       {isMobile && currentTab === null && (
         <div className="action-toggle">
           <button
@@ -66,9 +254,9 @@ function ActionPanel({ myPokemon, myTeam, activeMy, isTurnProcessing, onAction, 
                   return (
                     <button
                       key={move.name}
-                      className={`move-button ${effectivenessClass}`}
+                      className={`move-button ${effectivenessClass} ${currentTab === "fight" && myPokemon.base.moves[fightCursor]?.name === move.name ? "pad-focused" : ""}`}
                       onClick={() => onAction(move)}
-                      disabled={isTurnProcessing || isFainted || watchMode || myPokemon.unUsableMove?.name === move.name || myPokemon.pp[move.name] === 0}
+                      disabled={getMoveDisabledState(move)}
                     >
                       <span className="move-name">{move.name}</span>
                       <span className="move-power">{move.category}</span>
@@ -91,9 +279,9 @@ function ActionPanel({ myPokemon, myTeam, activeMy, isTurnProcessing, onAction, 
                   return (
                     <button
                       key={move.name}
-                      className={`move-button`}
+                      className={`move-button ${currentTab === "fight" && myPokemon.base.moves[fightCursor]?.name === move.name ? "pad-focused" : ""}`}
                       onClick={() => onAction(move)}
-                      disabled={isTurnProcessing || isFainted || watchMode}
+                      disabled={getMoveDisabledState(move)}
                     >
                       <span className="move-name">{move.name}</span>
                       <span className="move-pp">pp: {myPokemon.pp[move.name]} / {
@@ -127,6 +315,7 @@ function ActionPanel({ myPokemon, myTeam, activeMy, isTurnProcessing, onAction, 
             activeIndex={activeMy}
             onSwitch={(index) => onAction({ type: "switch", index })}
             watchMode={watchMode}
+            focusedSwitchIndex={currentTab === "switch" ? switchTargets[switchCursor]?.index ?? null : null}
           />
           {/* 모바일일 경우: 하단에 '싸운다' 버튼 보여줌 */}
           {isMobile && (

--- a/src/components/Battle.tsx
+++ b/src/components/Battle.tsx
@@ -22,10 +22,18 @@ import { useNavigate } from "react-router-dom";
 import { baseAiChooseAction } from "../utils/RL/baseAiChooseAction";
 import { BattlePokemon } from "../models/BattlePokemon";
 import { calculateOrder } from "../utils/battleLogics/calculateOrder";
+import BattlePad, { BattlePadAction } from "./BattlePad";
 
+type BattleProps = {
+  watchMode: boolean;
+  redMode: boolean;
+  randomMode: boolean;
+  watchCount: number;
+  watchDelay: number;
+  setBattleKey: React.Dispatch<React.SetStateAction<number>>;
+};
 
-
-function Battle({ watchMode, redMode, randomMode, watchCount, watchDelay, setBattleKey }) {
+function Battle({ watchMode, redMode, randomMode, watchCount, watchDelay, setBattleKey }: BattleProps) {
   const myTeam = useBattleStore((state) => state.myTeam);
   const enemyTeam = useBattleStore((state) => state.enemyTeam);
   const {
@@ -132,6 +140,13 @@ function Battle({ watchMode, redMode, randomMode, watchCount, watchDelay, setBat
   const [timeLeft, setTimeLeft] = useState(60); // 60초 제한
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const timeLeftRef = useRef(timeLeft);
+  const [padCommand, setPadCommand] = useState<{ id: number; action: BattlePadAction } | null>(null);
+  const padCommandIdRef = useRef(0);
+
+  const handlePadInput = useCallback((action: BattlePadAction) => {
+    padCommandIdRef.current += 1;
+    setPadCommand({ id: padCommandIdRef.current, action });
+  }, []);
   // useEffect(() => {
   //   timeLeftRef.current = timeLeft;
   //   console.log("💡 useEffect 타이머 리셋 트리거 확인", timeLeft);
@@ -255,7 +270,7 @@ function Battle({ watchMode, redMode, randomMode, watchCount, watchDelay, setBat
 
 
   const requestSwitch = (onSwitchConfirmed: (index: number) => void) => {
-    setPendingSwitch(() => (index) => {
+    setPendingSwitch(() => (index: number) => {
       onSwitchConfirmed(index);
       setIsSwitchModalOpen(false);
     });
@@ -267,7 +282,7 @@ function Battle({ watchMode, redMode, randomMode, watchCount, watchDelay, setBat
       console.log('유턴 효과 실행중...3')
       startTimer();
       setIsSwitchModalOpen(true);
-      setPendingSwitch(() => (index) => {
+      setPendingSwitch(() => (index: number) => {
         if (switchRequest?.onSwitch) {
           switchRequest.onSwitch(index); // zustand의 콜백 실행
           console.log('유턴 효과 실행중...4')
@@ -347,7 +362,7 @@ function Battle({ watchMode, redMode, randomMode, watchCount, watchDelay, setBat
   useEffect(() => {
     if (isFainted) {
       setIsSwitchModalOpen(true);
-      setPendingSwitch(() => async (index) => {
+      setPendingSwitch(() => async (index: number) => {
         console.log("my 포켓몬이 쓰러져서 교체 실행")
         await switchPokemon('my', index)
         clearSwitchRequest();
@@ -415,7 +430,7 @@ function Battle({ watchMode, redMode, randomMode, watchCount, watchDelay, setBat
 
   return (
 
-    <div className="battle-layout">
+    <div className={`battle-layout ${watchMode ? "" : "battle-layout--with-pad"}`}>
       <button
         onClick={() => {
           setMusicOn((prev) => {
@@ -424,23 +439,13 @@ function Battle({ watchMode, redMode, randomMode, watchCount, watchDelay, setBat
             return newState;
           });
         }}
-        style={{
-          position: "fixed", top: 10, right: 10, zIndex: 9999,
-          padding: "0.5rem", background: musicOn ? "#3f51b5" : "#999", color: "white"
-        }}
+        className={`music-toggle-button ${musicOn ? "is-on" : "is-off"}`}
       >
         {musicOn ? "브금 끄기" : "브금 켜기"}
       </button>
-      <button onClick={() => { console.log(myTeam[activeMy]) }}>
-        포켓몬 정보 디버깅용
-      </button>
       {
         (isSwitchModalOpen && !watchMode) && (
-          <div style={{
-            position: "fixed", top: 0, left: 0, width: "100%", height: "100%",
-            backgroundColor: "rgba(0, 0, 0, 0.5)", display: "flex",
-            justifyContent: "center", alignItems: "center", zIndex: 9999, flex: 1,
-          }}>
+          <div className="switch-modal-overlay">
             <div className="switch-modal">
               {isFainted && <h3>포켓몬이 쓰러졌습니다... 어느 포켓몬으로 교체하시겠습니까?</h3>}
               {!isFainted && <h3>어느 포켓몬으로 교체하시겠습니까?</h3>}
@@ -538,10 +543,17 @@ function Battle({ watchMode, redMode, randomMode, watchCount, watchDelay, setBat
             isTurnProcessing={isTurnProcessing}
             onAction={watchMode ? () => { } : executeTurn}
             watchMode={watchMode}
+            padCommand={padCommand}
           />
 
         </div>
       </div>
+      {!watchMode && (
+        <BattlePad
+          onInput={handlePadInput}
+          disabled={isTurnProcessing || isSwitchModalOpen}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/BattlePad.tsx
+++ b/src/components/BattlePad.tsx
@@ -1,0 +1,142 @@
+import React, { useCallback, useRef } from "react";
+
+export type BattlePadAction = "up" | "down" | "left" | "right" | "x" | "y" | "a" | "b";
+
+type BattlePadProps = {
+  onInput: (action: BattlePadAction) => void;
+  disabled?: boolean;
+};
+
+const repeatableActions = new Set<BattlePadAction>(["up", "down", "left", "right"]);
+
+function BattlePad({ onInput, disabled = false }: BattlePadProps) {
+  const repeatTimerRef = useRef<number | null>(null);
+  const repeatIntervalRef = useRef<number | null>(null);
+
+  const clearRepeat = useCallback(() => {
+    if (repeatTimerRef.current !== null) {
+      window.clearTimeout(repeatTimerRef.current);
+      repeatTimerRef.current = null;
+    }
+    if (repeatIntervalRef.current !== null) {
+      window.clearInterval(repeatIntervalRef.current);
+      repeatIntervalRef.current = null;
+    }
+  }, []);
+
+  const startPress = useCallback(
+    (action: BattlePadAction) => {
+      if (disabled) {
+        return;
+      }
+      onInput(action);
+      if (!repeatableActions.has(action)) {
+        return;
+      }
+      clearRepeat();
+      repeatTimerRef.current = window.setTimeout(() => {
+        repeatIntervalRef.current = window.setInterval(() => {
+          onInput(action);
+        }, 85);
+      }, 220);
+    },
+    [clearRepeat, disabled, onInput]
+  );
+
+  const endPress = useCallback(() => {
+    clearRepeat();
+  }, [clearRepeat]);
+
+  return (
+    <div className={`battle-pad ${disabled ? "battle-pad-disabled" : ""}`}>
+      <div className="battle-pad-left">
+        <button
+          className="pad-btn dpad-up"
+          type="button"
+          onPointerDown={() => startPress("up")}
+          onPointerUp={endPress}
+          onPointerLeave={endPress}
+          onPointerCancel={endPress}
+        >
+          ↑
+        </button>
+        <button
+          className="pad-btn dpad-left"
+          type="button"
+          onPointerDown={() => startPress("left")}
+          onPointerUp={endPress}
+          onPointerLeave={endPress}
+          onPointerCancel={endPress}
+        >
+          ←
+        </button>
+        <button
+          className="pad-btn dpad-right"
+          type="button"
+          onPointerDown={() => startPress("right")}
+          onPointerUp={endPress}
+          onPointerLeave={endPress}
+          onPointerCancel={endPress}
+        >
+          →
+        </button>
+        <button
+          className="pad-btn dpad-down"
+          type="button"
+          onPointerDown={() => startPress("down")}
+          onPointerUp={endPress}
+          onPointerLeave={endPress}
+          onPointerCancel={endPress}
+        >
+          ↓
+        </button>
+        <div className="pad-center" />
+      </div>
+
+      <div className="battle-pad-right">
+        <button
+          className="pad-btn face-btn y-btn"
+          type="button"
+          onPointerDown={() => startPress("y")}
+          onPointerUp={endPress}
+          onPointerLeave={endPress}
+          onPointerCancel={endPress}
+        >
+          Y
+        </button>
+        <button
+          className="pad-btn face-btn x-btn"
+          type="button"
+          onPointerDown={() => startPress("x")}
+          onPointerUp={endPress}
+          onPointerLeave={endPress}
+          onPointerCancel={endPress}
+        >
+          X
+        </button>
+        <button
+          className="pad-btn face-btn a-btn"
+          type="button"
+          onPointerDown={() => startPress("a")}
+          onPointerUp={endPress}
+          onPointerLeave={endPress}
+          onPointerCancel={endPress}
+        >
+          A
+        </button>
+        <button
+          className="pad-btn face-btn b-btn"
+          type="button"
+          onPointerDown={() => startPress("b")}
+          onPointerUp={endPress}
+          onPointerLeave={endPress}
+          onPointerCancel={endPress}
+        >
+          B
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default BattlePad;

--- a/src/components/BottomBar.css
+++ b/src/components/BottomBar.css
@@ -1,0 +1,27 @@
+.bottom-bar {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.9rem 1rem;
+  background: linear-gradient(180deg, #f8f0dd 0%, #efdfbc 100%);
+  border-top: 4px solid #d7c28d;
+  font-family: "IBM Plex Sans KR", "Noto Sans KR", sans-serif;
+  color: #4f4a3a;
+}
+
+.bottom-bar-text {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.bottom-bar-link {
+  color: #0b5cb8;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.bottom-bar-link:hover {
+  color: #083c78;
+}

--- a/src/components/BottomBar.tsx
+++ b/src/components/BottomBar.tsx
@@ -1,34 +1,20 @@
 import React from 'react';
+import './BottomBar.css';
 
 const BottomBar: React.FC = () => {
   return (
-    <div style={styles.container}>
-      <p style={styles.text}>© {new Date().getFullYear()} Yakemon. All rights reserved.</p>
+    <div className="bottom-bar">
+      <p className="bottom-bar-text">© {new Date().getFullYear()} Yakemon. All rights reserved.</p>
       <a
         href="https://github.com/Dindb-dong/Yakemon"
         target="_blank"
         rel="noopener noreferrer"
-        style={{ color: '#007bff', textDecoration: 'none' }}
+        className="bottom-bar-link"
       >
         Visit my GitHub
       </a>
     </div>
   );
-};
-
-const styles = {
-  container: {
-    width: '100%',
-    backgroundColor: '#f8f9fa',
-    textAlign: 'center' as 'center',
-    padding: '10px 0',
-    boxShadow: '0 -2px 5px rgba(0, 0, 0, 0.1)',
-  },
-  text: {
-    margin: 0,
-    fontSize: '14px',
-    color: '#6c757d',
-  },
 };
 
 export default BottomBar;

--- a/src/components/Leaderboard.css
+++ b/src/components/Leaderboard.css
@@ -1,64 +1,95 @@
 .leaderboard-container {
-  max-width: 800px;
-  margin: 2rem auto;
-  padding: 2rem;
+  max-width: 900px;
+  margin: 1.3rem auto 2rem;
+  padding: 1rem;
+  border: 4px solid #7f6a2f;
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(255, 251, 238, 0.96), rgba(245, 232, 192, 0.94));
+  box-shadow: 0 10px 18px rgba(52, 39, 12, 0.18);
+}
+
+.leaderboard-container h1 {
+  margin: 0 0 0.8rem;
+  font-family: "VT323", monospace;
+  font-size: 2.3rem;
 }
 
 .leaderboard-table {
-  background-color: white;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  border: 3px solid #6f5824;
+  border-radius: 12px;
   overflow: hidden;
 }
 
 .table-header {
   display: grid;
-  grid-template-columns: 80px 1fr 100px 100px;
-  padding: 1rem;
-  background-color: #2c3e50;
-  color: white;
-  font-weight: bold;
+  grid-template-columns: 80px 1fr 100px;
+  gap: 0.3rem;
+  padding: 0.75rem;
+  background: linear-gradient(180deg, #3f86d8, #255ea8);
+  color: #fff;
+  font-weight: 700;
 }
 
 .table-row {
   display: grid;
-  grid-template-columns: 80px 1fr 100px 100px;
-  padding: 1rem;
-  border-bottom: 1px solid #eee;
-  transition: background-color 0.3s ease;
+  grid-template-columns: 80px 1fr 100px;
+  gap: 0.3rem;
+  padding: 0.7rem 0.75rem;
+  border-top: 1px solid rgba(111, 88, 36, 0.25);
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.table-row:nth-child(odd) {
+  background: rgba(255, 248, 230, 0.9);
 }
 
 .table-row:hover {
-  background-color: #f8f9fa;
+  background: rgba(173, 220, 255, 0.4);
 }
 
-.table-row:last-child {
-  border-bottom: none;
-}
-
-.rank {
+.rank,
+.streak {
   text-align: center;
-  font-weight: bold;
+  font-weight: 700;
 }
 
 .username {
-  padding-left: 1rem;
+  padding-left: 0.35rem;
 }
 
-.streak, .wins {
+.loading,
+.error,
+.no-data {
   text-align: center;
-}
-
-.loading {
-  text-align: center;
-  padding: 2rem;
-  font-size: 1.2rem;
-  color: #666;
+  padding: 1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
 }
 
 .error {
-  text-align: center;
-  padding: 2rem;
-  color: #e74c3c;
-  font-size: 1.2rem;
-} 
+  color: #8d2a21;
+}
+
+.retry-button {
+  margin-top: 0.5rem;
+  border: 2px solid #2d240f;
+  border-radius: 9px;
+  background: linear-gradient(180deg, #4a8be8, #255fae);
+  color: #fff;
+  font-size: 0.82rem;
+  font-weight: 700;
+  padding: 0.42rem 0.8rem;
+  cursor: pointer;
+}
+
+@media (max-width: 680px) {
+  .leaderboard-container {
+    margin: 0.8rem;
+  }
+
+  .table-header,
+  .table-row {
+    grid-template-columns: 66px 1fr 80px;
+    font-size: 0.85rem;
+  }
+}

--- a/src/components/LogPanel.tsx
+++ b/src/components/LogPanel.tsx
@@ -10,8 +10,8 @@ function LogPanel({ logs }: { logs: string[] }) {
 
   return (
     <div className="log-panel">
-      <h4>전투 로그</h4>
-      <ul>
+      <h4 className="log-title">전투 로그</h4>
+      <ul className="log-list">
         {logs.map((log, idx) => (
           <li key={idx}>{log}</li>
         ))}

--- a/src/components/MyPage.css
+++ b/src/components/MyPage.css
@@ -27,6 +27,11 @@
   background-color: #2980b9;
 }
 
+.auth-buttons button:disabled {
+  background-color: #95a5a6;
+  cursor: not-allowed;
+}
+
 .auth-form {
   display: flex;
   flex-direction: column;
@@ -44,6 +49,11 @@
   border-radius: 4px;
 }
 
+.auth-form input:disabled {
+  background-color: #f5f6fa;
+  cursor: not-allowed;
+}
+
 .auth-form button {
   padding: 0.8rem;
   border: none;
@@ -56,6 +66,11 @@
 
 .auth-form button:hover {
   background-color: #2980b9;
+}
+
+.auth-form button:disabled {
+  background-color: #95a5a6;
+  cursor: not-allowed;
 }
 
 .mypage-container {
@@ -71,6 +86,25 @@
   margin-bottom: 2rem;
 }
 
+.user-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.user-info h1 {
+  margin: 0;
+  font-size: 2rem;
+  color: #2c3e50;
+}
+
+.user-info .username {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #666;
+  font-weight: normal;
+}
+
 .logout-button {
   padding: 0.5rem 1rem;
   border: none;
@@ -83,6 +117,11 @@
 
 .logout-button:hover {
   background-color: #c0392b;
+}
+
+.logout-button:disabled {
+  background-color: #95a5a6;
+  cursor: not-allowed;
 }
 
 .stats-container {

--- a/src/components/MyPage.css
+++ b/src/components/MyPage.css
@@ -1,162 +1,147 @@
-.auth-container {
-  max-width: 400px;
-  margin: 2rem auto;
-  padding: 2rem;
-  background-color: white;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+.auth-container,
+.mypage-container {
+  max-width: 860px;
+  margin: 1.3rem auto 2rem;
+  padding: 1.2rem;
+  border: 4px solid #7f6a2f;
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(255, 251, 238, 0.96), rgba(245, 232, 192, 0.94));
+  box-shadow: 0 10px 18px rgba(52, 39, 12, 0.18);
 }
 
 .auth-buttons {
   display: flex;
-  gap: 1rem;
   justify-content: center;
+  gap: 0.8rem;
 }
 
-.auth-buttons button {
-  padding: 0.8rem 1.5rem;
-  border: none;
-  border-radius: 4px;
-  background-color: #3498db;
-  color: white;
+.auth-buttons button,
+.auth-form button,
+.logout-button {
+  border: 2px solid #2d240f;
+  border-radius: 10px;
+  color: #fff;
+  font-size: 0.86rem;
+  font-weight: 700;
+  padding: 0.6rem 0.9rem;
   cursor: pointer;
-  transition: background-color 0.3s ease;
 }
 
-.auth-buttons button:hover {
-  background-color: #2980b9;
+.auth-buttons button,
+.auth-form button {
+  background: linear-gradient(180deg, #4a8be8, #255fae);
 }
 
-.auth-buttons button:disabled {
-  background-color: #95a5a6;
+.auth-form button[type="button"] {
+  background: linear-gradient(180deg, #c86f53, #9e3f2b);
+}
+
+.auth-buttons button:disabled,
+.auth-form button:disabled,
+.logout-button:disabled {
+  background: #9c9a93;
+  border-color: #7f7c75;
   cursor: not-allowed;
 }
 
 .auth-form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.7rem;
 }
 
 .auth-form h2 {
+  margin: 0.2rem 0 0.4rem;
   text-align: center;
-  margin-bottom: 1rem;
+  font-family: "VT323", monospace;
+  font-size: 2rem;
 }
 
 .auth-form input {
-  padding: 0.8rem;
-  border: 1px solid #ddd;
-  border-radius: 4px;
+  border: 2px solid #aa9258;
+  border-radius: 8px;
+  padding: 0.6rem 0.65rem;
+  font-size: 0.9rem;
 }
 
 .auth-form input:disabled {
-  background-color: #f5f6fa;
-  cursor: not-allowed;
-}
-
-.auth-form button {
-  padding: 0.8rem;
-  border: none;
-  border-radius: 4px;
-  background-color: #3498db;
-  color: white;
-  cursor: pointer;
-  transition: background-color 0.3s ease;
-}
-
-.auth-form button:hover {
-  background-color: #2980b9;
-}
-
-.auth-form button:disabled {
-  background-color: #95a5a6;
-  cursor: not-allowed;
-}
-
-.mypage-container {
-  max-width: 800px;
-  margin: 2rem auto;
-  padding: 2rem;
+  background: #f1ece0;
 }
 
 .mypage-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 2rem;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .user-info {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4rem;
 }
 
 .user-info h1 {
   margin: 0;
-  font-size: 2rem;
-  color: #2c3e50;
+  font-family: "VT323", monospace;
+  font-size: 2.4rem;
 }
 
 .user-info .username {
   margin: 0;
-  font-size: 1.2rem;
-  color: #666;
-  font-weight: normal;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #5f4c24;
 }
 
 .logout-button {
-  padding: 0.5rem 1rem;
-  border: none;
-  border-radius: 4px;
-  background-color: #e74c3c;
-  color: white;
-  cursor: pointer;
-  transition: background-color 0.3s ease;
-}
-
-.logout-button:hover {
-  background-color: #c0392b;
-}
-
-.logout-button:disabled {
-  background-color: #95a5a6;
-  cursor: not-allowed;
+  background: linear-gradient(180deg, #dd5e4a, #ab3527);
 }
 
 .stats-container {
+  margin-top: 1rem;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1.5rem;
-  margin-top: 2rem;
+  gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
 .stat-box {
-  background-color: white;
-  padding: 1.5rem;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  border: 3px solid #7f6a2f;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.62);
   text-align: center;
+  padding: 0.75rem;
 }
 
 .stat-box h3 {
   margin: 0;
-  color: #666;
-  font-size: 1rem;
+  font-size: 0.9rem;
+  color: #5f4c24;
 }
 
 .stat-box p {
-  margin: 0.5rem 0 0;
+  margin: 0.3rem 0 0;
+  font-family: "VT323", monospace;
   font-size: 2rem;
-  font-weight: bold;
-  color: #2c3e50;
+  color: #264d8a;
 }
 
 .error-message {
-  background-color: #f8d7da;
-  color: #721c24;
-  padding: 0.75rem;
-  border-radius: 4px;
-  margin-bottom: 1rem;
+  border: 2px solid #b23b2f;
+  border-radius: 8px;
+  padding: 0.45rem 0.55rem;
+  margin-bottom: 0.7rem;
+  background: #ffd9d5;
+  color: #7d241a;
+  font-size: 0.85rem;
+  font-weight: 600;
   text-align: center;
-} 
+}
+
+@media (max-width: 640px) {
+  .auth-container,
+  .mypage-container {
+    margin: 0.8rem;
+  }
+}

--- a/src/components/MyPage.css
+++ b/src/components/MyPage.css
@@ -15,6 +15,29 @@
   gap: 0.8rem;
 }
 
+.guest-mode-box {
+  border: 2px dashed #8b7538;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.65);
+  padding: 0.7rem;
+  margin-bottom: 0.8rem;
+}
+
+.guest-mode-box h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.guest-mode-box p {
+  margin: 0.3rem 0 0;
+  font-size: 0.84rem;
+}
+
+.guest-id {
+  font-family: "VT323", monospace;
+  font-size: 1.1rem !important;
+}
+
 .auth-buttons button,
 .auth-form button,
 .logout-button {

--- a/src/components/MyPage.tsx
+++ b/src/components/MyPage.tsx
@@ -16,6 +16,7 @@ const MyPage = () => {
   const [showSignupForm, setShowSignupForm] = useState(false);
   const [userStats, setUserStats] = useState<User | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -31,6 +32,7 @@ const MyPage = () => {
 
   const fetchUserProfile = async () => {
     try {
+      setIsLoading(true);
       const profile = await getProfile();
       setUserStats(profile);
       setError(null);
@@ -47,12 +49,15 @@ const MyPage = () => {
       } else {
         setError('프로필을 불러오는데 실패했습니다.');
       }
+    } finally {
+      setIsLoading(false);
     }
   };
 
   const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);
+    setIsLoading(true);
     const formData = new FormData(e.currentTarget);
     const email = formData.get('email') as string;
     const password = formData.get('password') as string;
@@ -70,12 +75,15 @@ const MyPage = () => {
       } else {
         setError('로그인에 실패했습니다. 잠시 후 다시 시도해주세요.');
       }
+    } finally {
+      setIsLoading(false);
     }
   };
 
   const handleSignup = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);
+    setIsLoading(true);
     const formData = new FormData(e.currentTarget);
     const username = formData.get('username') as string;
     const email = formData.get('email') as string;
@@ -84,11 +92,13 @@ const MyPage = () => {
 
     if (password !== confirmPassword) {
       setError('비밀번호가 일치하지 않습니다.');
+      setIsLoading(false);
       return;
     }
 
     if (password.length < 6) {
       setError('비밀번호는 6자 이상이어야 합니다.');
+      setIsLoading(false);
       return;
     }
 
@@ -109,6 +119,8 @@ const MyPage = () => {
       } else {
         setError('회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.');
       }
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -125,36 +137,62 @@ const MyPage = () => {
         {error && <div className="error-message">{error}</div>}
         {!showLoginForm && !showSignupForm && (
           <div className="auth-buttons">
-            <button onClick={() => setShowLoginForm(true)}>로그인</button>
-            <button onClick={() => setShowSignupForm(true)}>회원가입</button>
+            <button
+              onClick={() => setShowLoginForm(true)}
+              disabled={isLoading}
+            >
+              로그인
+            </button>
+            <button
+              onClick={() => setShowSignupForm(true)}
+              disabled={isLoading}
+            >
+              회원가입
+            </button>
           </div>
         )}
 
         {showLoginForm && (
           <form onSubmit={handleLogin} className="auth-form">
             <h2>로그인</h2>
-            <input type="email" name="email" placeholder="이메일" required />
-            <input type="password" name="password" placeholder="비밀번호" required />
-            <button type="submit">로그인</button>
-            <button type="button" onClick={() => {
-              setShowLoginForm(false);
-              setError(null);
-            }}>취소</button>
+            <input type="email" name="email" placeholder="이메일" required disabled={isLoading} />
+            <input type="password" name="password" placeholder="비밀번호" required disabled={isLoading} />
+            <button type="submit" disabled={isLoading}>
+              {isLoading ? '로그인 중...' : '로그인'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setShowLoginForm(false);
+                setError(null);
+              }}
+              disabled={isLoading}
+            >
+              취소
+            </button>
           </form>
         )}
 
         {showSignupForm && (
           <form onSubmit={handleSignup} className="auth-form">
             <h2>회원가입</h2>
-            <input type="text" name="username" placeholder="사용자명" required />
-            <input type="email" name="email" placeholder="이메일" required />
-            <input type="password" name="password" placeholder="비밀번호" required />
-            <input type="password" name="confirmPassword" placeholder="비밀번호 확인" required />
-            <button type="submit">가입하기</button>
-            <button type="button" onClick={() => {
-              setShowSignupForm(false);
-              setError(null);
-            }}>취소</button>
+            <input type="text" name="username" placeholder="사용자명" required disabled={isLoading} />
+            <input type="email" name="email" placeholder="이메일" required disabled={isLoading} />
+            <input type="password" name="password" placeholder="비밀번호" required disabled={isLoading} />
+            <input type="password" name="confirmPassword" placeholder="비밀번호 확인" required disabled={isLoading} />
+            <button type="submit" disabled={isLoading}>
+              {isLoading ? '가입 중...' : '가입하기'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setShowSignupForm(false);
+                setError(null);
+              }}
+              disabled={isLoading}
+            >
+              취소
+            </button>
           </form>
         )}
       </div>
@@ -164,8 +202,13 @@ const MyPage = () => {
   return (
     <div className="mypage-container">
       <div className="mypage-header">
-        <h1>마이페이지</h1>
-        <button onClick={handleLogout} className="logout-button">로그아웃</button>
+        <div className="user-info">
+          <h1>마이페이지</h1>
+          <h2 className="username">유저 이름: {userStats?.username}</h2>
+        </div>
+        <button onClick={handleLogout} className="logout-button" disabled={isLoading}>
+          {isLoading ? '로딩 중...' : '로그아웃'}
+        </button>
       </div>
       {error && <div className="error-message">{error}</div>}
       {userStats && (

--- a/src/components/MyPage.tsx
+++ b/src/components/MyPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { login, register, getProfile } from '../api/auth';
 import { User } from '../types/user';
 import { getAccessToken, setAccessToken, removeAccessToken } from '../utils/storage';
+import { getOrCreateGuestPlayerId } from '../api/playhistory';
 import './MyPage.css';
 
 interface ApiError {
@@ -17,9 +18,11 @@ const MyPage = () => {
   const [userStats, setUserStats] = useState<User | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [guestId, setGuestId] = useState('');
   const navigate = useNavigate();
 
   useEffect(() => {
+    setGuestId(getOrCreateGuestPlayerId());
     const checkToken = async () => {
       const token = await getAccessToken();
       if (token) {
@@ -134,6 +137,12 @@ const MyPage = () => {
   if (!isLoggedIn) {
     return (
       <div className="auth-container">
+        <div className="guest-mode-box">
+          <h3>게스트 기록 모드</h3>
+          <p>현재 전적 저장은 게스트 ID 기준으로 동작합니다.</p>
+          <p>인증 백엔드가 연결되지 않으면 로그인/회원가입은 동작하지 않습니다.</p>
+          <p className="guest-id">ID: {guestId.slice(-12)}</p>
+        </div>
         {error && <div className="error-message">{error}</div>}
         {!showLoginForm && !showSignupForm && (
           <div className="auth-buttons">

--- a/src/components/PokemonSelect.tsx
+++ b/src/components/PokemonSelect.tsx
@@ -27,11 +27,8 @@ export function PokemonDetailModal({
   realign: boolean;
 }) {
   return (
-    <div style={{
-      position: "fixed", top: 0, left: 0, width: "100%", height: "100%",
-      backgroundColor: "rgba(0, 0, 0, 0.5)", display: "flex", justifyContent: "center", alignItems: "center"
-    }}>
-      <div style={{ background: "#fff", padding: "2rem", borderRadius: "10px", width: "400px", fontSize: "0.8rem" }}>
+    <div className="pokemon-modal-overlay">
+      <div className="pokemon-modal">
         <h2>{pokemon.name}</h2>
         <p>타입: {pokemon.types.join(", ")}</p>
         {/* <p>특성: {typeof pokemon.ability === 'string' ? pokemon.ability : pokemon.ability?.name ?? '없음'}</p> */}
@@ -42,14 +39,14 @@ export function PokemonDetailModal({
         <p>특수방어력: {realign ? pokemon.spDefense : pokemon.spDefense + 20}</p>
         <p>스피드: {realign ? pokemon.speed : pokemon.speed + 20}</p>
 
-        <div style={{ marginTop: "1rem" }}>
+        <div className="pokemon-modal-actions">
           {!isAlreadySelected && (
-            <button onClick={() => onSelect(pokemon)} style={{ marginRight: "1rem" }}>
+            <button onClick={() => onSelect(pokemon)}>
               등록하기
             </button>
           )}
           {isAlreadySelected && (
-            <button onClick={() => onSelect(pokemon)} style={{ marginRight: "1rem" }}>
+            <button onClick={() => onSelect(pokemon)}>
               취소하기
             </button>
           )}
@@ -154,10 +151,7 @@ function PokemonSelect({ onSelect }: Props) {
             return newState;
           });
         }}
-        style={{
-          position: "fixed", top: 10, right: 10, zIndex: 9999,
-          padding: "0.5rem", background: musicOn ? "#3f51b5" : "#999", color: "white"
-        }}
+        className={`music-toggle-button ${musicOn ? "is-on" : "is-off"}`}
       >
         {musicOn ? "브금 끄기" : "브금 켜기"}
       </button>
@@ -169,34 +163,26 @@ function PokemonSelect({ onSelect }: Props) {
             AudioManager.getInstance().play("main");
           }
         }} />
-      )}<div style={{ padding: "2rem" }}>
-        <h2>내 포켓몬 3마리 선택</h2>
-        <div style={{ display: "flex", flexWrap: "wrap" }}>
+      )}<div className="select-screen">
+        <h2 className="select-title">내 포켓몬 3마리 선택</h2>
+        <div className="pokemon-grid">
           {sortedPokemon.map((p) => {
             const selectedIndex = selected.indexOf(p);
             return (
               <button
                 key={p.id}
                 onClick={() => openDetailModal(p)}
-                style={{
-                  backgroundColor: selected.includes(p) ? "#00bcd4" : "#eee",
-                  margin: "0.5rem",
-                  padding: "0.5rem 1rem",
-                  position: "relative",
-                  border: "1px solid #ccc",
-                  borderRadius: "6px",
-                  minWidth: "80px",
-                }}
+                className={`pokemon-chip ${selected.includes(p) ? "selected" : ""}`}
               >
-                <div style={{ flexDirection: "row", display: "flex" }}>
+                <div className="pokemon-chip-content">
                   <img
                     src={thumbnails[p.id]}
                     alt={p.name}
-                    style={{ width: "25px", height: "25px", objectFit: "contain", marginRight: 10, borderRadius: 6 }}
+                    className="pokemon-thumb"
                   />
 
-                  <div style={{ flexDirection: "column", display: "flex" }}>
-                    <div style={{ fontSize: "0.7rem", color: "#333" }}>
+                  <div className="pokemon-chip-text">
+                    <div className="pokemon-type">
                       {p.types.join(", ")}
                     </div>
 
@@ -206,18 +192,7 @@ function PokemonSelect({ onSelect }: Props) {
 
 
                 {selectedIndex >= 0 && (
-                  <div
-                    style={{
-                      position: "absolute",
-                      top: "-6px",
-                      right: "-16px",
-                      fontSize: "0.75rem",
-                      color: "#fff",
-                      backgroundColor: "#333",
-                      padding: "2px 6px",
-                      borderRadius: "12px",
-                    }}
-                  >
+                  <div className="selected-order">
                     {selectedIndex + 1}번째
                   </div>
                 )}
@@ -225,27 +200,11 @@ function PokemonSelect({ onSelect }: Props) {
             );
           })}
         </div>
-        <br />
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "row",
-            justifyContent: "space-around", // 세로축 중앙 정렬
-          }}
-        >
+        <div className="battle-buttons">
           <button
             disabled={selected.length !== 3}
             onClick={() => onSelect(selected, false, false, false)}
-            style={{
-              marginTop: "1rem",
-              padding: "1rem 2rem",
-              backgroundColor: selected.length !== 3 ? "#676767" : "#7ea1ff",
-              borderRadius: "6px",
-              color: "#fff",
-              fontSize: "0.7rem",
-              border: "none",
-              cursor: selected.length === 3 ? "pointer" : "not-allowed"
-            }}
+            className="start-button normal"
           >
             배틀 시작
           </button>
@@ -261,24 +220,15 @@ function PokemonSelect({ onSelect }: Props) {
           <button
             disabled={selected.length !== 3}
             onClick={() => onSelect(selected, false, true, false)}
-            style={{
-              marginTop: "1rem",
-              padding: "1rem 2rem",
-              backgroundColor: selected.length !== 3 ? "#676767" : "#FF0000FF",
-              borderRadius: "6px",
-              color: "#fff",
-              fontSize: "0.7rem",
-              border: "none",
-              cursor: selected.length === 3 ? "pointer" : "not-allowed"
-            }}
+            className="start-button red"
           >
             레드와 배틀 시작
           </button>
         </div>
 
-        <div>
+        <div className="watch-mode">
           <h3>관전 모드</h3>
-          <div style={{ marginTop: "2rem", flexDirection: "row", flex: 1, display: "flex" }}>
+          <div className="watch-row">
             {/* <div style={{ flex: 0.3 }}> TODO: 관전횟수는 나중에 추가
       <h5>관전 횟수</h5>
       <input
@@ -289,19 +239,20 @@ function PokemonSelect({ onSelect }: Props) {
         style={{ marginRight: "0.5rem", padding: "0.25rem 0.5rem" }}
       />
     </div> */}
-            <div style={{ flex: 0.45 }}>
+            <div className="watch-input-wrap">
               <h5>관전 딜레이 타임</h5>
               <input
                 type="number"
                 min={1}
                 value={watchDelay}
                 onChange={(t) => setWatchDelay(parseFloat(t.target.value))}
-                style={{ marginRight: "0.5rem", padding: "0.25rem 0.5rem" }} />
+                className="watch-input"
+              />
             </div>
 
             <button
               onClick={() => onSelect(selected.length === 3 ? selected : [], true, true, false, watchCount, watchDelay)}
-              style={{ padding: "0.5rem 1rem", flex: 0.55 }}
+              className="watch-start-button"
             >
               관전 시작
             </button>

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -1,23 +1,37 @@
-// Result.tsx
 import React, { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import AudioManager from "../utils/AudioManager";
 import { useBattleStore } from "../Context/useBattleStore";
-import Modal from "./Modal"; // 선택 UI용 모달 컴포넌트 필요 (아래에 예시도 있음)
 import HintModal from "./HintModal";
-import { createMockPokemon } from "../data/mockPokemon";
+import Modal from "./Modal";
+import RealignModal from "./RealignModal";
 import { createBattlePokemon } from "../utils/battleLogics/createBattlePokemon";
 import { resetBattlePokemon } from "../utils/resetBattlePokemon";
 import { resetEnvironment } from "../utils/battleLogics/updateEnvironment";
-import { replace, useNavigate } from "react-router-dom";
-import { PokemonInfo } from "../models/Pokemon";
 import { shuffleArray } from "../utils/shuffle";
-import { createGen1Pokemon, createGen2Pokemon, createGen3Pokemon, createGen4Pokemon, createGen5Pokemon, createGen6Pokemon, createGen7Pokemon, createGen8Pokemon, createGen9Pokemon } from "../data/createWincountPokemon";
-import RealignModal from "./RealignModal";
+import {
+  createGen1Pokemon,
+  createGen2Pokemon,
+  createGen3Pokemon,
+  createGen4Pokemon,
+  createGen5Pokemon,
+  createGen6Pokemon,
+  createGen7Pokemon,
+  createGen8Pokemon,
+  createGen9Pokemon,
+} from "../data/createWincountPokemon";
 import { BattlePokemon } from "../models/BattlePokemon";
 import { delay } from "../utils/delay";
-import { updateWinCount, updateWinStreak, addPlayHistory, GameError } from "../api/playhistory";
+import { addPlayHistory, GameError, getOrCreateGuestPlayerId, updateWinCount, updateWinStreak } from "../api/playhistory";
+import { PokemonInfo } from "../models/Pokemon";
 
-function Result({ winner, setBattleKey, randomMode }: { winner: string; setBattleKey: React.Dispatch<React.SetStateAction<number>>; randomMode: boolean }) {
+type ResultProps = {
+  winner: string;
+  setBattleKey: React.Dispatch<React.SetStateAction<number>>;
+  randomMode: boolean;
+};
+
+function Result({ winner, setBattleKey, randomMode }: ResultProps) {
   const {
     myTeam,
     enemyTeam,
@@ -29,8 +43,9 @@ function Result({ winner, setBattleKey, randomMode }: { winner: string; setBattl
     setTurn,
     addLog,
     setWinCount,
-    resetAll
+    resetAll,
   } = useBattleStore();
+
   const gen1Pokemon = createGen1Pokemon();
   const gen2Pokemon = gen1Pokemon.concat(createGen2Pokemon());
   const gen3Pokemon = gen2Pokemon.concat(createGen3Pokemon());
@@ -40,55 +55,58 @@ function Result({ winner, setBattleKey, randomMode }: { winner: string; setBattl
   const gen7Pokemon = gen6Pokemon.concat(createGen7Pokemon());
   const gen8Pokemon = gen7Pokemon.concat(createGen8Pokemon());
   const gen9Pokemon = gen8Pokemon.concat(createGen9Pokemon());
-  const [musicOn, setMusicOn] = useState(true);
+
   const navigate = useNavigate();
-  const [showHintModal, setShowHintModal] = useState(false);         // 힌트용 모달
-  const [showExchangeModal, setShowExchangeModal] = useState(false); // 교체용 모달
-  const [showRealignModal, setShowRealignModal] = useState(false);   // 순서 정렬 모달
+  const [musicOn, setMusicOn] = useState(true);
+  const [showHintModal, setShowHintModal] = useState(false);
+  const [showExchangeModal, setShowExchangeModal] = useState(false);
+  const [showRealignModal, setShowRealignModal] = useState(false);
   const memorizedEnemyRef = useRef<BattlePokemon[] | null>(null);
   const [apiError, setApiError] = useState<string | null>(null);
+  const [saveStatusText, setSaveStatusText] = useState<string>("");
 
   const isVictory = winner === "AI에게 승리!" || winner === "왼쪽 플레이어 승리";
+  const guestPlayerId = getOrCreateGuestPlayerId();
 
   useEffect(() => {
-    async function initialize() {
-      if (isVictory) {
-        try {
-          // 게임 결과 업데이트
-          await updateWinStreak('win');
-          await addPlayHistory('win');
-          memorizedEnemyRef.current = enemyTeam.map((p) => ({
-            ...p,
-            base: { ...p.base },
-            pp: { ...p.pp },
-            rank: { ...p.rank },
-            status: [...p.status],
-          }));
-          await delay(1000);
-          generateNewRandomPokemon();
-          setShowHintModal(true);
-        } catch (error) {
-          if (error instanceof GameError) {
-            setApiError(error.message);
-          } else {
-            setApiError('게임 기록 업데이트에 실패했습니다.');
-          }
+    async function initializeResult() {
+      const mode = randomMode ? "random" : "normal";
+
+      try {
+        if (isVictory) {
+          const winResult = await updateWinStreak("win");
+          await addPlayHistory("win", mode);
+          setSaveStatusText(`기록 저장 완료 · 현재 연승 ${winResult.winStreak}`);
+        } else {
+          const loseResult = await updateWinCount("lose");
+          await addPlayHistory("lose", mode);
+          setSaveStatusText(`기록 저장 완료 · 승 ${loseResult.winCount} / 패 ${loseResult.loseCount}`);
         }
-      } else {
-        try {
-          // 패배 시에도 기록 업데이트
-          await updateWinCount('lose');
-          await addPlayHistory('lose');
-        } catch (error) {
-          if (error instanceof GameError) {
-            setApiError(error.message);
-          } else {
-            setApiError('게임 기록 업데이트에 실패했습니다.');
-          }
+      } catch (error) {
+        if (error instanceof GameError) {
+          setApiError(error.message);
+        } else {
+          setApiError("기록 저장 중 오류가 발생했습니다.");
         }
       }
+
+      if (isVictory) {
+        memorizedEnemyRef.current = enemyTeam.map((pokemon) => ({
+          ...pokemon,
+          base: { ...pokemon.base },
+          pp: { ...pokemon.pp },
+          rank: { ...pokemon.rank },
+          status: [...pokemon.status],
+        }));
+
+        await delay(1000);
+        generateNewRandomPokemon();
+        setShowHintModal(true);
+      }
     }
-    initialize();
+
+    initializeResult();
+
     if (musicOn) {
       AudioManager.getInstance().play(isVictory ? "win" : "defeat");
     } else {
@@ -96,8 +114,11 @@ function Result({ winner, setBattleKey, randomMode }: { winner: string; setBattl
     }
 
     return () => AudioManager.getInstance().stop();
-  }, [musicOn]);
+  }, [isVictory, musicOn, randomMode]);
 
+  /**
+   * Generate next enemy team for random battle progression.
+   */
   function generateNewRandomPokemon() {
     const allGens = [
       gen1Pokemon,
@@ -111,175 +132,168 @@ function Result({ winner, setBattleKey, randomMode }: { winner: string; setBattl
       gen9Pokemon,
     ];
 
-    // winCount가 0이면 gen1, 1이면 gen2, ..., 8 이상이면 gen9
     const index = Math.min(winCount, allGens.length - 1);
     const pokemonList = shuffleArray(allGens[index]);
-
     const enemyRaw: PokemonInfo[] = [];
 
-    // 1. 첫 번째 포켓몬 랜덤 선택
     const first = pokemonList[Math.floor(Math.random() * pokemonList.length)];
     enemyRaw.push(first);
 
-    // 2. 두 번째 포켓몬 - 첫 번째와 타입 겹치지 않는 것 중 랜덤
-    const secondPool = pokemonList.filter(p =>
-      !p.types.some(type => first.types.includes(type)) &&
-      !enemyRaw.includes(p)
+    const secondPool = pokemonList.filter(
+      (pokemon) => !pokemon.types.some((type) => first.types.includes(type)) && !enemyRaw.includes(pokemon)
     );
-    if (secondPool.length === 0) return; // 예외 처리
+    if (secondPool.length === 0) {
+      return;
+    }
     const second = secondPool[Math.floor(Math.random() * secondPool.length)];
     enemyRaw.push(second);
 
-    // 3. 세 번째 포켓몬 - 두 마리와 타입 2개 이상 겹치지 않는 것 중 랜덤
     const combinedTypes = [...first.types, ...second.types];
-    const thirdPool = pokemonList.filter(p => {
-      if (enemyRaw.includes(p)) return false;
-      const overlap = p.types.filter(type => combinedTypes.includes(type));
+    const thirdPool = pokemonList.filter((pokemon) => {
+      if (enemyRaw.includes(pokemon)) {
+        return false;
+      }
+      const overlap = pokemon.types.filter((type) => combinedTypes.includes(type));
       return overlap.length < 1;
     });
-    if (thirdPool.length === 0) return; // 예외 처리
+    if (thirdPool.length === 0) {
+      return;
+    }
     const third = thirdPool[Math.floor(Math.random() * thirdPool.length)];
     enemyRaw.push(third);
 
-    // 무작위 셔플
     const shuffledEnemy = enemyRaw.sort(() => Math.random() - 0.5);
-    const newEnemyTeam = shuffledEnemy.map((p) => createBattlePokemon(p));
-    newEnemyTeam.forEach((p) => p.currentHp = 0);
+    const newEnemyTeam = shuffledEnemy.map((pokemon) => createBattlePokemon(pokemon));
+    newEnemyTeam.forEach((pokemon) => {
+      pokemon.currentHp = 0;
+    });
     setEnemyTeam(newEnemyTeam);
   }
 
+  /**
+   * Start the next random battle with refreshed state.
+   */
   const startNextBattle = () => {
-    // 상태 초기화
-    enemyTeam.forEach((p) => p.currentHp = p.base.hp);
+    enemyTeam.forEach((pokemon) => {
+      pokemon.currentHp = pokemon.base.hp;
+    });
+
     resetEnvironment();
     setActiveMy(0);
     setActiveEnemy(0);
     setTurn(1);
     setWinCount(winCount + 1);
     addLog(`${winCount + 2}번째 전투 시작!`);
+
     setTimeout(() => {
-      // 💡 배틀 리셋하려면 navigate로 다시 진입
-      setBattleKey(prev => prev + 1); // 👈 이걸 통해 완전히 새로운 Battle 시작
+      setBattleKey((prev) => prev + 1);
     }, 300);
-
-
   };
 
+  /**
+   * Exchange one of my team members with one memorized enemy and continue flow.
+   */
   const handleExchange = (myIndex: number, enemyIndex: number) => {
     const memorizedTeam = memorizedEnemyRef.current;
-    if (!memorizedTeam) return;
-    console.log("🎯 선택된 enemy base:", memorizedTeam[enemyIndex].base.memorizedBase ?? memorizedTeam[enemyIndex].base);
-    const newMyTeam = [...myTeam];
-    // 교체한 포켓몬을 먼저 생성한 뒤 초기화
-    const exchanged = createBattlePokemon(memorizedTeam[enemyIndex].base.memorizedBase ?? memorizedTeam[enemyIndex].base, true);
-    console.log("🧪 생성된 교체 포켓몬:", exchanged);
-    newMyTeam[myIndex] = exchanged;
+    if (!memorizedTeam) {
+      return;
+    }
 
-    const resetTeam = newMyTeam.map((p) => resetBattlePokemon(p)); // 나머지도 초기화
+    const newMyTeam = [...myTeam];
+    const exchanged = createBattlePokemon(memorizedTeam[enemyIndex].base.memorizedBase ?? memorizedTeam[enemyIndex].base, true);
+    newMyTeam[myIndex] = exchanged;
+    const resetTeam = newMyTeam.map((pokemon) => resetBattlePokemon(pokemon));
 
     setMyTeam(resetTeam);
     setShowExchangeModal(false);
     setShowRealignModal(true);
   };
 
+  /**
+   * Skip exchange phase and continue to realign flow.
+   */
   const handleSkip = () => {
-    setMyTeam(myTeam.map((p) => resetBattlePokemon(p)));
+    setMyTeam(myTeam.map((pokemon) => resetBattlePokemon(pokemon)));
     setShowExchangeModal(false);
     setShowRealignModal(true);
   };
 
   return (
-    <>
-      {apiError && (
-        <div style={{
-          position: 'fixed',
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-          background: 'rgba(255, 0, 0, 0.1)',
-          padding: '1rem',
-          borderRadius: '8px',
-          zIndex: 10000
-        }}>
-          {apiError}
-        </div>
-      )}
+    <div className="result-screen">
+      <button
+        onClick={() => {
+          setMusicOn((prev) => {
+            const nextState = !prev;
+            AudioManager.getInstance().mute(!nextState);
+            return nextState;
+          });
+        }}
+        className={`music-toggle-button ${musicOn ? "is-on" : "is-off"}`}
+      >
+        {musicOn ? "브금 끄기" : "브금 켜기"}
+      </button>
+
       {showHintModal && isVictory && randomMode && (
         <HintModal
           enemyTeam={enemyTeam}
           onClose={() => {
             setShowHintModal(false);
-            setShowExchangeModal(true); // 교체 모달로 이동
-          }}
-        />
-      )}
-      {showExchangeModal && (
-        <Modal
-          myTeam={myTeam}
-          enemyTeam={memorizedEnemyRef.current ?? []}
-          onExchange={(myIndex, enemyIndex) => {
-            handleExchange(myIndex, enemyIndex);
-          }}
-          onSkip={handleSkip}
-        />
-      )}
-      {showRealignModal && (
-        <RealignModal
-          myTeam={myTeam}
-          onConfirm={(newOrder) => {
-            const newTeam = newOrder.map((i) => myTeam[i]);
-            setMyTeam(newTeam);
-            setShowRealignModal(false);
-            startNextBattle(); // 최종적으로 전투 시작
+            setShowExchangeModal(true);
           }}
         />
       )}
 
-      <button
-        onClick={() => {
-          setMusicOn((prev) => {
-            const newState = !prev;
-            AudioManager.getInstance().mute(!newState);
-            return newState;
-          });
-        }}
-        style={{
-          position: "fixed", top: 10, right: 10, zIndex: 9999,
-          padding: "0.5rem", background: musicOn ? "#3f51b5" : "#999", color: "white"
-        }}
-      >
-        {musicOn ? "브금 끄기" : "브금 켜기"}
-      </button>
-      {/* {isVictory && randomMode && !showExchangeModal && !showHintModal && !showRealignModal && (
-        <div style={{ padding: "2rem", textAlign: "center" }}>
-          <h1>{winner}</h1>
-          <button onClick={handleSkip}>다음 전투 시작</button>
+      {showExchangeModal && (
+        <Modal
+          myTeam={myTeam}
+          enemyTeam={memorizedEnemyRef.current ?? []}
+          onExchange={(myIndex, enemyIndex) => handleExchange(myIndex, enemyIndex)}
+          onSkip={handleSkip}
+        />
+      )}
+
+      {showRealignModal && (
+        <RealignModal
+          myTeam={myTeam}
+          onConfirm={(newOrder) => {
+            const newTeam = newOrder.map((index) => myTeam[index]);
+            setMyTeam(newTeam);
+            setShowRealignModal(false);
+            startNextBattle();
+          }}
+        />
+      )}
+
+      <div className="result-card">
+        <h1 className="result-title">{winner}</h1>
+        {randomMode && !isVictory && <p className="result-subtitle">{winCount} 연승에서 도전 종료</p>}
+
+        <div className="result-save-box">
+          <p className="result-save-id">플레이어 ID: {guestPlayerId.slice(-12)}</p>
+          {saveStatusText && <p className="result-save-status">{saveStatusText}</p>}
+          {apiError && <p className="result-save-error">{apiError}</p>}
+          {!apiError && (
+            <p className="result-save-help">
+              로그인 없이 브라우저 기준으로 전적이 저장됩니다.
+            </p>
+          )}
         </div>
-      )} */}
-      {!isVictory && (
-        <div style={{ padding: "2rem", textAlign: "center" }}>
-          <h1>{winner}</h1>
-          {randomMode && (<h1>{winCount} 연승에서 실패...</h1>)}
-          <button onClick={() => {
-            navigate('/', { replace: true })
-            resetAll()
-          }}>
+
+        {!isVictory || !randomMode ? (
+          <button
+            className="result-main-button"
+            onClick={() => {
+              navigate("/", { replace: true });
+              resetAll();
+            }}
+          >
             새로운 전투 시작
           </button>
-        </div>
-      )}
-      {isVictory && !randomMode && (
-        <div style={{ padding: "2rem", textAlign: "center" }}>
-          <h1>{winner}</h1>
-          <button onClick={() => {
-            navigate('/', { replace: true })
-            resetAll()
-          }}>
-            새로운 전투 시작
-          </button>
-        </div>
-      )}
-    </>
+        ) : (
+          <p className="result-flow-hint">상대 교체/정렬 단계를 완료하면 다음 전투가 시작됩니다.</p>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/src/components/SwapPanel.tsx
+++ b/src/components/SwapPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { BattlePokemon } from "../models/BattlePokemon";
 import { useBattleStore } from "../Context/useBattleStore";
 
@@ -7,12 +7,20 @@ type Props = {
   activeIndex: number;
   onSwitch: (index: number) => void;
   watchMode: boolean;
+  focusedSwitchIndex?: number | null;
 };
 
-function SwapPanel({ team, activeIndex, onSwitch, watchMode }: Props) {
+function SwapPanel({ team, activeIndex, onSwitch, watchMode, focusedSwitchIndex = null }: Props) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [viewingIndex, setViewingIndex] = useState<number | null>(null);
-  const { isSwitchWaiting } = useBattleStore.getState()
+
+  useEffect(() => {
+    if (focusedSwitchIndex === null) {
+      return;
+    }
+    setSelectedIndex(focusedSwitchIndex);
+  }, [focusedSwitchIndex]);
+
   const toggleView = (index: number) => {
     setViewingIndex((prev) => (prev === index ? null : index));
   };
@@ -29,6 +37,7 @@ function SwapPanel({ team, activeIndex, onSwitch, watchMode }: Props) {
         return (
           <div key={poke.base.name} className="swap-slot">
             <button
+              className={focusedSwitchIndex === i ? "pad-focused" : ""}
               onClick={() => setSelectedIndex(i)} disabled={isFainted || watchMode}
             >
               {poke.base.name} {isCurrent ? "(현재)" : ""}

--- a/src/components/TimerBar.tsx
+++ b/src/components/TimerBar.tsx
@@ -11,18 +11,14 @@ function TimerBar({ timeLeft }: { timeLeft: number }) {
   }
 
   return (
-    <div style={{
-      width: "100%",
-      height: "10px",
-      backgroundColor: "#ccc",
-      margin: "10px 0"
-    }}>
-      <div style={{
-        height: "100%",
-        width: `${percentage}%`,
-        backgroundColor: barColor,
-        transition: "width 1s linear"
-      }} />
+    <div className="timer-bar-shell">
+      <div
+        className="timer-bar-fill"
+        style={{
+          width: `${percentage}%`,
+          backgroundColor: barColor,
+        }}
+      />
     </div>
   );
 }

--- a/src/components/TopBar.css
+++ b/src/components/TopBar.css
@@ -25,6 +25,7 @@
   text-decoration: none;
   font-size: 1rem;
   transition: color 0.3s ease;
+  padding-right: 60px;
 }
 
 .nav-links a:hover {

--- a/src/components/TopBar.css
+++ b/src/components/TopBar.css
@@ -1,33 +1,61 @@
 .top-bar {
+  position: sticky;
+  top: 0;
+  z-index: 1100;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem 2rem;
-  background-color: #2c3e50;
-  color: white;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  gap: 1rem;
+  padding: 0.8rem 1.2rem;
+  border-bottom: 4px solid #6f5824;
+  background:
+    radial-gradient(circle at 10% 25%, rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0) 30%),
+    linear-gradient(180deg, #3e90de 0%, #255da2 100%);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.22);
 }
 
 .logo a {
-  color: white;
   text-decoration: none;
-  font-size: 1.5rem;
-  font-weight: bold;
+  color: #fff;
+  font-family: "VT323", monospace;
+  font-size: 2rem;
+  letter-spacing: 0.04em;
+  text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.35);
 }
 
 .nav-links {
   display: flex;
-  gap: 2rem;
+  gap: 0.6rem;
 }
 
 .nav-links a {
-  color: white;
   text-decoration: none;
-  font-size: 1rem;
-  transition: color 0.3s ease;
-  padding-right: 60px;
+  color: #fff;
+  font-weight: 700;
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  border-radius: 10px;
+  padding: 0.38rem 0.72rem;
+  background: rgba(10, 27, 58, 0.24);
 }
 
 .nav-links a:hover {
-  color: #3498db;
-} 
+  background: rgba(255, 255, 255, 0.2);
+}
+
+@media (max-width: 600px) {
+  .top-bar {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 0.8rem;
+  }
+
+  .nav-links {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .nav-links a {
+    text-align: center;
+  }
+}

--- a/src/components/TurnBanner.tsx
+++ b/src/components/TurnBanner.tsx
@@ -95,13 +95,13 @@ function TurnBanner({ turn, randomMode }: { turn: number, randomMode: boolean })
       )}
 
       {/* 필드 효과 */}
-      <div style={{ display: "flex", justifyContent: "space-between", marginTop: "0.5rem", fontSize: "0.85rem" }}>
-        <div>
+      <div className="side-effects-row">
+        <div className="side-effects left">
           {mySideEffects.map((eff, i) => (
             <div key={i}>🟩 {eff}</div>
           ))}
         </div>
-        <div>
+        <div className="side-effects right">
           {enemySideEffects.map((eff, i) => (
             <div key={i}>🟥 {eff}</div>
           ))}

--- a/src/index.css
+++ b/src/index.css
@@ -1,363 +1,804 @@
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR:wght@400;500;700&family=VT323&display=swap");
+
+:root {
+  --ui-bg: #f5ecd4;
+  --ui-panel: #fff9e8;
+  --ui-panel-strong: #f6e7be;
+  --ui-border: #7f6a2f;
+  --ui-accent: #d6452f;
+  --ui-accent-soft: #f3c453;
+  --ui-green: #4b9b5f;
+  --ui-blue: #2369bb;
+  --ui-text: #312710;
+  --ui-shadow: 0 10px 18px rgba(52, 39, 12, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: "IBM Plex Sans KR", "Noto Sans KR", sans-serif;
+  color: var(--ui-text);
+  background:
+    radial-gradient(circle at 15% 15%, #fff7df 0%, rgba(255, 247, 223, 0) 45%),
+    radial-gradient(circle at 85% 8%, #e8f5d4 0%, rgba(232, 245, 212, 0) 40%),
+    linear-gradient(180deg, #e8d6a7 0%, #f3e4c2 40%, #f8eed8 100%);
+  background-attachment: fixed;
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  font-family: inherit;
+}
+
 .battle-layout {
-  padding: 1rem;
+  position: relative;
+  max-width: 1300px;
+  margin: 0 auto;
+  padding: 1rem 1.2rem 1.8rem;
 }
 
-.switch-modal {
+.battle-layout--with-pad {
+  padding-bottom: 240px;
+}
+
+.music-toggle-button {
   position: fixed;
-  top: 10%;
-  left: 50%;
-  height: 80vh;
-  overflow: scroll;
-  transform: translateX(-50%);
-  background: white;
-  border: 2px solid black;
-  padding: 16px;
-  z-index: 9999;
-}
-
-.random-button {
-  margin-top: 1rem;
-  padding: 1rem 2rem;
-  background-color: #66D16D;
-  border-radius: 6px;
+  top: 0.8rem;
+  right: 1rem;
+  z-index: 1200;
+  border: 2px solid #221b0c;
+  border-radius: 10px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 0.45rem 0.75rem;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.25);
   color: #fff;
-  font-size: 0.7rem;
-  border: none;
   cursor: pointer;
-  transition: background-color 0.2s ease;
 }
 
-.random-button:hover {
-  background-color: #6ce274;
-  color:#e2e2e2
+.music-toggle-button.is-on {
+  background: linear-gradient(180deg, #5b88e5, #2d4f96);
+}
+
+.music-toggle-button.is-off {
+  background: linear-gradient(180deg, #9c9a92, #6f6d63);
 }
 
 .turn-banner {
-  text-align: center;
-  font-size: 1.5rem;
-  font-weight: bold;
   margin-bottom: 1rem;
+  border: 4px solid var(--ui-border);
+  border-radius: 14px;
+  background: linear-gradient(180deg, var(--ui-panel) 0%, #efe1b7 100%);
+  box-shadow: var(--ui-shadow);
+  padding: 0.8rem 1rem;
+  text-align: center;
+  font-family: "VT323", monospace;
+  font-size: 1.6rem;
+  letter-spacing: 0.03em;
+}
+
+.public-env {
+  margin-top: 0.35rem;
+  font-family: "IBM Plex Sans KR", "Noto Sans KR", sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.side-effects-row {
+  margin-top: 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-family: "IBM Plex Sans KR", "Noto Sans KR", sans-serif;
+  font-size: 0.8rem;
+  text-align: left;
+}
+
+.side-effects {
+  flex: 1;
+  border: 1px solid rgba(49, 39, 16, 0.15);
+  border-radius: 8px;
+  padding: 0.4rem 0.55rem;
+  background: rgba(255, 255, 255, 0.55);
 }
 
 .main-area {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(520px, 1.7fr) minmax(300px, 1fr);
   gap: 1rem;
 }
 
 .pokemon_log {
-  flex: 2;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.7rem;
 }
 
-.pokemon-area {
-  flex: 0.7;
-  display: flex;
+.timer-bar-shell {
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  border: 2px solid #5a471a;
+  overflow: hidden;
+  background: rgba(77, 66, 38, 0.3);
 }
 
-.pokemon-card {
-  border: 1px solid #ccc;
-  padding: 1rem;
-  width: 48%;
-  height: 90%;
-}
-.pokemon-area p {
-  font-size: 0.9rem; /* 기본 사이즈 줄이기 */
-  margin: 0.3rem 0;
-}
-
-.side-panel {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.action-panel > div {
-  margin-bottom: 1rem;
+.timer-bar-fill {
+  height: 100%;
+  transition: width 1s linear;
 }
 
 .log-panel {
-  flex: 0.8;
-  max-height: 120px;
-  overflow-y: auto;
-  background: #f7f7f7;
-  padding: 0.5rem;
-  border: 1px solid #ddd;
-  font-size: 0.9rem;
-}
-
-.status-card {
-  background: #f8f8f8;
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  margin-top: 0.5rem;
-  border-radius: 6px;
-  font-size: 0.9rem;
-  flex:auto;
-}
-
-.swap-panel {
-  flex: 1;
-  padding: 0.5rem;
-  background: #fefefe;
-  border: 1px solid #ddd;
-  border-radius: 6px;
-  max-height: 70vh;
-  overflow-y: auto;
-}
-
-.swap-slot {
-  margin-bottom: 0.75rem;
-  flex-direction: column;
-  justify-content: center;
-  align-self: center;
-  align-content: center;
-  align-items: center;
-}
-
-.swap-slot button {
-  margin: 0.3rem;
-  margin-left: 0;
-  padding: 0.4rem 0.8rem;
-  font-size: 0.95rem;
-  border: none;
-  border-radius: 4px;
-  background-color: #74b7fb;
-  color: white;
-  cursor: pointer;
-  transition: background-color 0.2s ease-in-out;
-}
-
-.swap-slot button:disabled {
-  background-color: #aaa;
-  cursor: not-allowed;
-}
-
-.swap-slot button:hover:not(:disabled) {
-  background-color: #1565c0;
-}
-
-.status-card {
-  background: #f0f4f8;
-  padding: 0.75rem;
-  border: 1px solid #bbb;
-  border-radius: 6px;
-  font-size: 0.85rem;
-  margin-top: 0.5rem;
-  animation: fadeIn 0.2s ease-in-out;
-}
-
-.status-card p {
-  margin: 0.25rem 0;
-}
-
-.status-card ul {
-  list-style: none;
-  padding-left: 0;
-}
-
-.status-card li {
-  margin-left: 0.5rem;
-}
-
-.hint-toggle {
-  background-color: #2d8fff86;
-  width: 40%;
-  height: 40px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  padding: 0.5rem;
-  text-align: center;
-  font-weight: 600;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  justify-self: center;
-  align-items: center;
-  align-content: center;
-  font-size: 0.8rem;
-  transition: background-color 0.2s ease-in-out;
-  align-self: center;
-  margin-bottom: 3%;
-}
-
-.hint-toggle:hover:not(:disabled) {
-  background-color: #2d8fff;
-}
-
-/* 기술 선택 버튼 그리드 */
-.move-grid {
-  flex: 1;
-  display: grid;
-  background: #fefefe;
-  grid-template-columns: repeat(2, 1fr); /* 2개씩 정렬 */
-  gap: 0.75rem;
-  margin-bottom: 1rem;
-}
-
-.move-button {
-  background-color: #f1f1f1;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  padding: 1rem;
-  text-align: center;
-  font-weight: 500;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  font-size: 0.95rem;
-  transition: background-color 0.2s ease-in-out;
-}
-
-.move-button:hover:not(:disabled) {
-  background-color: #d5d5d5;
-}
-
-.move-button:disabled {
-  background-color: #aaa;
-  color: #eee;
-  cursor: not-allowed;
-}
-
-.move-button .move-name {
-  font-weight: bold;
-  display: block;
-  font-size: 1.1em;
-}
-
-.move-button .move-pp,
-.move-button .move-power,
-.move-button .move-accuracy {
-  display: block;
-  font-size: 0.9em;
-  color: #555;
-  margin-top: 2px;
-}
-
-.move-name {
-  font-size: 1rem;
-  align-self: center;
-  text-align: center;
-}
-
-.move-pp {
-  font-size: 0.75rem;
-  color: #333;
-  align-self: center;
-  text-align: center;
-}
-
-.move-type {
-  margin-top: 0.4rem;
-  padding: 0.2rem 0.5rem;
+  border: 3px solid #5b4820;
   border-radius: 12px;
-  font-size: 0.75rem;
-  font-weight: bold;
-  color: white;
-  display: inline-block;
-  align-self: center;
-  text-align: center;
+  background: #f8f1da;
+  box-shadow: var(--ui-shadow);
+  max-height: 210px;
+  overflow-y: auto;
+  padding: 0.6rem 0.8rem;
 }
 
-/* 타입별 색상 설정 */
-.move-type.불 { background-color: #F08030; }
-.move-type.물 { background-color: #4375e8; }
-.move-type.풀 { background-color: #78C850; }
-.move-type.전기 { background-color: #F8D030; }
-.move-type.얼음 { background-color: #98D8D8; }
-.move-type.격투 { background-color: #C03028; }
-.move-type.비행 { background-color: #a2b9f3; }
-.move-type.에스퍼 { background-color: #F85888; }
-.move-type.바위 { background-color: #B8A038; }
-.move-type.고스트 { background-color: #705898; }
-.move-type.드래곤 { background-color: #4412c4; }
-.move-type.악 { background-color: #160e09; }
-.move-type.강철 { background-color: #8b8b9a; }
-.move-type.페어리 { background-color: #EE99AC; }
-.move-type.노말 { background-color: #f7f7f7; color:#160e09;}
-.move-type.독 { background-color: #A040A0; }
-.move-type.땅 { background-color: #e0b94e; }
-.move-type.벌레 { background-color: #A8B820; }
-
-.move-power,
-.move-accuracy {
-  font-size: 0.75rem;
-  color: #444;
-  align-self: center;
-  text-align: center;
+.log-title {
+  margin: 0 0 0.45rem;
+  font-family: "VT323", monospace;
+  font-size: 1.5rem;
+  letter-spacing: 0.03em;
 }
 
-.move-button.effective {
-  background-color: #fff7cc; /* 연한 노랑 */
+.log-list {
+  margin: 0;
+  padding: 0 0 0 1.1rem;
+  font-size: 0.87rem;
+  line-height: 1.45;
 }
 
-.move-button.very-effective {
-  background-color: #ffe066; /* 노랑 */
+.pokemon-area {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.7rem;
 }
 
-.move-button.not-effective {
-  background-color: #9b9b9b; /* 연한 회색 */
+.pokemon-card {
+  min-height: 280px;
+  border: 3px solid #5b4820;
+  border-radius: 16px;
+  background:
+    linear-gradient(180deg, rgba(254, 248, 228, 0.97), rgba(246, 229, 181, 0.94)),
+    repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.18) 0 8px, rgba(255, 255, 255, 0.04) 8px 16px);
+  box-shadow: var(--ui-shadow);
+  padding: 0.85rem 0.8rem;
 }
 
-.move-button.not-very-effective {
-  background-color: #5d5d5d; /* 연한 회색 */
+.pokemon-card h5 {
+  margin: 0 0 0.5rem;
+  font-size: 0.96rem;
+  font-weight: 700;
 }
 
-.move-button.no-effect {
-  background-color: #393939; /* 어두운 회색 */
+.pokemon-card p {
+  margin: 0.25rem 0;
+  font-size: 0.86rem;
+  line-height: 1.35;
+}
+
+.pokemon-image {
+  width: min(120px, 100%);
+  height: auto;
+  margin: 0.25rem auto 0.5rem;
+  display: block;
+  image-rendering: pixelated;
 }
 
 .hp-bar-container {
   width: 100%;
   height: 12px;
-  background-color: #ddd;
-  border: 1px solid #aaa;
-  border-radius: 6px;
-  margin: 4px 0 8px;
+  background: rgba(73, 57, 27, 0.16);
+  border: 2px solid #5b4820;
+  border-radius: 999px;
   overflow: hidden;
+  margin: 0.3rem 0 0.45rem;
 }
 
 .hp-bar {
   height: 100%;
-  transition: width 0.3s ease-in-out;
+  transition: width 0.3s ease;
 }
 
-/* 체력 비율에 따라 색 변경 */
 .hp-green {
-  background-color: #4caf50; /* 초록 */
+  background: linear-gradient(180deg, #8ddd80, #3f8f44);
 }
 
 .hp-yellow {
-  background-color: #fbc02d; /* 노랑 */
+  background: linear-gradient(180deg, #fee884, #d6a73b);
 }
 
 .hp-red {
-  background-color: #f44336; /* 빨강 */
+  background: linear-gradient(180deg, #ff8b7b, #bc3324);
 }
 
-.pokemon-image {
+.side-panel {
+  border: 3px solid var(--ui-border);
+  border-radius: 16px;
+  background: linear-gradient(180deg, #fdf7e7 0%, #f2e3b6 100%);
+  box-shadow: var(--ui-shadow);
+  padding: 0.8rem;
+}
+
+.action-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.hint-toggle {
   width: 100%;
-  max-width: 100px;
+  border: 2px solid #3a2f13;
+  background: linear-gradient(180deg, #6cc5f5 0%, #338dcb 100%);
+  color: #fefefe;
+  border-radius: 10px;
+  padding: 0.55rem 0.7rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.hint-toggle:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.pad-help {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #4e4125;
+  border: 1px dashed rgba(78, 65, 37, 0.4);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.5);
+  padding: 0.35rem 0.55rem;
+}
+
+.move-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.move-button {
+  border: 2px solid #4f3f1d;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #f7f7f7 0%, #ddd8c8 100%);
+  color: #2e240d;
+  min-height: 118px;
+  text-align: left;
+  padding: 0.7rem 0.7rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  box-shadow: 0 3px 0 #7f6a2f;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+  cursor: pointer;
+}
+
+.move-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+}
+
+.move-button:disabled {
+  cursor: not-allowed;
+  color: #7c7560;
+  background: #cbc7bb;
+  box-shadow: none;
+}
+
+.move-name {
   display: block;
-  margin: 0 auto 0.5rem;
+  font-weight: 700;
+  font-size: 0.98rem;
 }
 
-@keyframes fadeIn {
-  from { opacity: 0; transform: translateY(-5px); }
-  to { opacity: 1; transform: translateY(0); }
+.move-pp,
+.move-power,
+.move-accuracy {
+  font-size: 0.76rem;
+  color: rgba(46, 36, 13, 0.82);
 }
 
-@keyframes shakeAndFlash {
-  0%   { transform: translateX(0); background-color: transparent; }
-  25%  { transform: translateX(-4px); background-color: rgba(255, 0, 0, 0.2); }
-  50%  { transform: translateX(4px); background-color: rgba(255, 0, 0, 0.4); }
-  75%  { transform: translateX(-2px); background-color: rgba(255, 0, 0, 0.2); }
-  100% { transform: translateX(0); background-color: transparent; }
+.move-type {
+  margin-top: 0.2rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-self: flex-start;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.14rem 0.5rem;
+  color: #fff;
+}
+
+.move-type.불 { background-color: #ef6d2b; }
+.move-type.물 { background-color: #2a74d8; }
+.move-type.풀 { background-color: #55ae41; }
+.move-type.전기 { background-color: #d6a314; }
+.move-type.얼음 { background-color: #4ba4b5; }
+.move-type.격투 { background-color: #a3381b; }
+.move-type.비행 { background-color: #708fcf; }
+.move-type.에스퍼 { background-color: #d34b83; }
+.move-type.바위 { background-color: #8f7a2e; }
+.move-type.고스트 { background-color: #5d4b95; }
+.move-type.드래곤 { background-color: #4a26af; }
+.move-type.악 { background-color: #4e4037; }
+.move-type.강철 { background-color: #728295; }
+.move-type.페어리 { background-color: #cb6a8a; }
+.move-type.노말 { background-color: #dbd7ce; color: #433625; }
+.move-type.독 { background-color: #8651aa; }
+.move-type.땅 { background-color: #c69a4b; }
+.move-type.벌레 { background-color: #7d9327; }
+
+.move-button.effective {
+  background: linear-gradient(180deg, #fff7cc, #f8eb99);
+}
+
+.move-button.very-effective {
+  background: linear-gradient(180deg, #ffe88b, #ffcb2e);
+}
+
+.move-button.not-effective {
+  background: linear-gradient(180deg, #d5d4cc, #b8b7af);
+}
+
+.move-button.not-very-effective {
+  background: linear-gradient(180deg, #9f9f97, #7d7d75);
+}
+
+.move-button.no-effect {
+  background: linear-gradient(180deg, #797972, #5e5e57);
+  color: #f4f4f4;
+}
+
+.move-button.no-effect .move-pp,
+.move-button.no-effect .move-power,
+.move-button.no-effect .move-accuracy {
+  color: #e2e2e2;
+}
+
+.pad-focused {
+  outline: 3px solid var(--ui-accent);
+  outline-offset: 1px;
+  animation: padFocusPulse 1s infinite;
+}
+
+@keyframes padFocusPulse {
+  0% { box-shadow: 0 0 0 rgba(214, 69, 47, 0.45); }
+  50% { box-shadow: 0 0 12px rgba(214, 69, 47, 0.45); }
+  100% { box-shadow: 0 0 0 rgba(214, 69, 47, 0.45); }
+}
+
+.swap-panel {
+  border: 2px solid #5a481f;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.5);
+  padding: 0.65rem;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.swap-panel h3 {
+  margin: 0 0 0.6rem;
+  font-family: "VT323", monospace;
+  font-size: 1.4rem;
+}
+
+.swap-slot {
+  margin-bottom: 0.65rem;
+}
+
+.swap-slot button {
+  border: 2px solid #3f6eb3;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #66a9ff, #3373d7);
+  color: #fff;
+  font-size: 0.82rem;
+  font-weight: 700;
+  padding: 0.42rem 0.7rem;
+  margin-right: 0.4rem;
+  margin-bottom: 0.4rem;
+  cursor: pointer;
+}
+
+.swap-slot button:hover:not(:disabled) {
+  filter: brightness(1.07);
+}
+
+.swap-slot button:disabled {
+  background: #8e8e8e;
+  border-color: #7a7a7a;
+  cursor: not-allowed;
+}
+
+.status-card {
+  margin-top: 0.45rem;
+  border: 1px solid #b7a571;
+  border-radius: 8px;
+  padding: 0.4rem 0.55rem;
+  background: #fff4d6;
+  font-size: 0.78rem;
+}
+
+.status-card p {
+  margin: 0.2rem 0;
+}
+
+.status-card ul {
+  margin: 0.2rem 0 0;
+  padding-left: 1rem;
+}
+
+.status-card li {
+  margin: 0.15rem 0;
+}
+
+.action-toggle {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.action-toggle-btn {
+  border: 2px solid #2e4f89;
+  background: linear-gradient(180deg, #74abff, #4574cc);
+  color: #fff;
+  border-radius: 10px;
+  padding: 0.5rem 0.6rem;
+  font-size: 0.84rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.action-toggle-btn:disabled {
+  border-color: #7b7b7b;
+  background: #999;
+  cursor: not-allowed;
+}
+
+.switch-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 4000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+}
+
+.switch-modal {
+  width: min(700px, 100%);
+  max-height: 85vh;
+  overflow-y: auto;
+  background: #fff8e4;
+  border: 4px solid #6f5824;
+  border-radius: 14px;
+  box-shadow: var(--ui-shadow);
+  padding: 1rem;
+}
+
+.switch-modal h3 {
+  margin-top: 0;
+}
+
+.battle-pad {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 200px;
+  padding: 1rem 1.5rem calc(1rem + env(safe-area-inset-bottom));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: linear-gradient(180deg, #dbceb1 0%, #a79b81 100%);
+  border-top: 4px solid #5f4d28;
+  box-shadow: 0 -6px 18px rgba(0, 0, 0, 0.22);
+  touch-action: none;
+  z-index: 3000;
+}
+
+.battle-pad-disabled {
+  opacity: 0.7;
+}
+
+.battle-pad-left {
+  width: min(240px, 42vw);
+  height: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  place-items: center;
+}
+
+.dpad-up { grid-column: 2; grid-row: 1; }
+.dpad-left { grid-column: 1; grid-row: 2; }
+.dpad-right { grid-column: 3; grid-row: 2; }
+.dpad-down { grid-column: 2; grid-row: 3; }
+
+.pad-center {
+  grid-column: 2;
+  grid-row: 2;
+  width: 52px;
+  height: 52px;
+  border-radius: 12px;
+  border: 2px solid #302613;
+  background: linear-gradient(180deg, #726853 0%, #4b4334 100%);
+}
+
+.battle-pad-right {
+  width: min(240px, 42vw);
+  height: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  place-items: center;
+}
+
+.y-btn { grid-column: 2; grid-row: 1; }
+.x-btn { grid-column: 1; grid-row: 2; }
+.a-btn { grid-column: 3; grid-row: 2; }
+.b-btn { grid-column: 2; grid-row: 3; }
+
+.pad-btn {
+  width: 58px;
+  height: 58px;
+  border-radius: 14px;
+  border: 2px solid #271f10;
+  background: linear-gradient(180deg, #847760 0%, #544b39 100%);
+  color: #fff;
+  font-size: 1.2rem;
+  font-weight: 700;
+  box-shadow: 0 4px 0 rgba(20, 16, 8, 0.8);
+  user-select: none;
+  cursor: pointer;
+}
+
+.face-btn {
+  border-radius: 999px;
+}
+
+.x-btn {
+  background: linear-gradient(180deg, #3d6bc0, #1d468f);
+}
+
+.y-btn {
+  background: linear-gradient(180deg, #7a5dbd, #4e3684);
+}
+
+.a-btn {
+  background: linear-gradient(180deg, #da5a3f, #a53322);
+}
+
+.b-btn {
+  background: linear-gradient(180deg, #3aa162, #237044);
+}
+
+.pad-btn:active {
+  transform: translateY(2px);
+  box-shadow: 0 2px 0 rgba(20, 16, 8, 0.8);
+}
+
+.select-screen {
+  max-width: 1240px;
+  margin: 1.2rem auto 1.8rem;
+  border: 4px solid #7f6a2f;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 252, 239, 0.95), rgba(243, 230, 191, 0.95));
+  box-shadow: var(--ui-shadow);
+  padding: 1.1rem;
+}
+
+.select-title {
+  margin: 0 0 0.9rem;
+  font-family: "VT323", monospace;
+  font-size: 2rem;
+  letter-spacing: 0.02em;
+}
+
+.pokemon-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 0.5rem;
+  max-height: 52vh;
+  overflow-y: auto;
+  padding-right: 0.3rem;
+}
+
+.pokemon-chip {
+  position: relative;
+  border: 2px solid #7d6a39;
+  border-radius: 12px;
+  padding: 0.45rem 0.5rem;
+  background: linear-gradient(180deg, #ffffff 0%, #ebe3cf 100%);
+  cursor: pointer;
+}
+
+.pokemon-chip:hover {
+  border-color: #2164ba;
+}
+
+.pokemon-chip.selected {
+  border-color: #0f5eb2;
+  background: linear-gradient(180deg, #c9ebff 0%, #8fd0ff 100%);
+}
+
+.pokemon-chip-content {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.pokemon-thumb {
+  width: 30px;
+  height: 30px;
+  object-fit: contain;
+  image-rendering: pixelated;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 6px;
+}
+
+.pokemon-chip-text {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.pokemon-type {
+  font-size: 0.64rem;
+  color: #61522d;
+}
+
+.selected-order {
+  position: absolute;
+  top: -0.45rem;
+  right: -0.5rem;
+  border-radius: 999px;
+  background: #1f2d48;
+  color: #fff;
+  font-size: 0.66rem;
+  font-weight: 700;
+  padding: 0.12rem 0.46rem;
+}
+
+.battle-buttons {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  justify-content: center;
+}
+
+.start-button,
+.random-button,
+.watch-start-button {
+  border: 2px solid #2d240f;
+  border-radius: 10px;
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 0.65rem 0.95rem;
+  cursor: pointer;
+}
+
+.start-button:disabled {
+  background: #9b968a;
+  border-color: #7f7a70;
+  color: #ececec;
+  cursor: not-allowed;
+}
+
+.start-button.normal {
+  background: linear-gradient(180deg, #548dff, #2c5dc5);
+}
+
+.start-button.red {
+  background: linear-gradient(180deg, #ec5b43, #ae2418);
+}
+
+.random-button {
+  background: linear-gradient(180deg, #5aba63, #2f8742);
+}
+
+.watch-mode {
+  margin-top: 1rem;
+  border: 2px solid #7f6a2f;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.5);
+  padding: 0.7rem;
+}
+
+.watch-mode h3,
+.watch-mode h5 {
+  margin: 0;
+}
+
+.watch-row {
+  display: flex;
+  gap: 0.7rem;
+  align-items: flex-end;
+  margin-top: 0.6rem;
+}
+
+.watch-input-wrap {
+  flex: 1;
+}
+
+.watch-input {
+  margin-top: 0.35rem;
+  width: 100%;
+  border: 2px solid #a78e54;
+  border-radius: 8px;
+  padding: 0.45rem 0.5rem;
+  font-size: 0.85rem;
+}
+
+.watch-start-button {
+  background: linear-gradient(180deg, #e0a953, #b07825);
+  white-space: nowrap;
+}
+
+.pokemon-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 4200;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+}
+
+.pokemon-modal {
+  width: min(440px, 100%);
+  border: 4px solid #6f5824;
+  border-radius: 14px;
+  background: #fff8e3;
+  padding: 1rem 1.1rem;
+  box-shadow: var(--ui-shadow);
+  font-size: 0.86rem;
+}
+
+.pokemon-modal h2 {
+  margin-top: 0;
+}
+
+.pokemon-modal p {
+  margin: 0.28rem 0;
+}
+
+.pokemon-modal-actions {
+  margin-top: 0.75rem;
+  display: flex;
+  gap: 0.45rem;
+}
+
+.pokemon-modal-actions button {
+  border: 2px solid #2d240f;
+  border-radius: 8px;
+  background: #2f72d0;
+  color: #fff;
+  padding: 0.45rem 0.7rem;
+  cursor: pointer;
 }
 
 .damage-effect {
@@ -369,164 +810,84 @@
   background-color: rgba(0, 255, 0, 0.1);
 }
 
+@keyframes shakeAndFlash {
+  0% { transform: translateX(0); background-color: transparent; }
+  25% { transform: translateX(-4px); background-color: rgba(255, 0, 0, 0.2); }
+  50% { transform: translateX(4px); background-color: rgba(255, 0, 0, 0.35); }
+  75% { transform: translateX(-2px); background-color: rgba(255, 0, 0, 0.2); }
+  100% { transform: translateX(0); background-color: transparent; }
+}
+
 @keyframes healFlash {
-  0%   { background-color: rgba(0, 255, 0, 0.15); }
-  50%  { background-color: rgba(0, 255, 0, 0.3); }
+  0% { background-color: rgba(0, 255, 0, 0.12); }
+  50% { background-color: rgba(0, 255, 0, 0.3); }
   100% { background-color: rgba(0, 255, 0, 0.1); }
 }
 
-/* 모바일 반응형 */
-@media (max-width: 768px) {
+@media (max-width: 1080px) {
   .main-area {
-    flex-direction: column;
-  }
-  .pokemon-area {
-    flex-direction: row;
-  }
-  .pokemon-area p {
-    font-size: 0.85rem;
-  }
-  .side-panel {
-    flex-direction: column;
-  }
-  .action-panel {
-    display: flex;
-    flex:1;
-    flex-direction: column;
-    justify-content: space-between;
-  }
-  .swap-slot {
-    flex-direction: row;
-  }
-  .swap-panel {
-    flex-direction: row;
-    max-height: 60vh;
-    overflow-y: auto;
-  }
-  .swap-slot button {
-    width: 100%;
-    font-size: 1rem;
-  }
-  .status-card {
-    font-size: 0.85rem;
-  }
-  .move-grid {
-    display: grid;
-    grid-template-columns: (4,1fr);
-    width: 100%;
+    grid-template-columns: 1fr;
   }
 
-  .move-button {
-    font-size: 0.85rem;
-    padding: 0.75rem;
-    height: 90%;
-    width: 100%; /* 👉 가로 꽉 차게 */
-    box-sizing: border-box;
-  }
-
-  .move-button .move-name {
-    font-size: 1rem;
-    text-align: center;
-  }
-
-  .move-button .move-pp,
-  .move-button .move-power,
-  .move-button .move-accuracy,
-  .move-button .move-type {
-    font-size: 0.75rem;
-    text-align: center;
-  }
-
-  .action-toggle {
-    display: flex;
-    justify-content: space-around;
-    margin-bottom: 0.75rem;
-  }
-  
-  .action-toggle-btn {
-    padding: 0.6rem 1.2rem;
-    font-size: 1rem;
-    background-color: #6c9ffb;
-    color: white;
-    border: none;
-    border-radius: 8px;
-    cursor: pointer;
-    transition: background-color 0.2s;
-  }
-  
-  .action-toggle-btn:disabled {
-    background-color: #ccc;
-    cursor: not-allowed;
-  }
-  
-  .action-toggle-btn:hover:not(:disabled) {
-    background-color: #1565c0;
-  }
-
-  .log-panel {
-    max-height: 80px;
+  .battle-layout--with-pad {
+    padding-bottom: 230px;
   }
 }
 
+@media (max-width: 768px) {
+  .battle-layout {
+    padding: 0.75rem;
+  }
 
-/* === 매우 작은 화면 (예: 480px 이하 스마트폰) === */
-@media (max-width: 480px) {
-  .move-grid {
-    display: grid;
-    grid-template-columns: (4,1fr); 
-    gap: 0.5rem;
-    width: 100%;
+  .turn-banner {
+    font-size: 1.35rem;
   }
+
   .pokemon-area {
-    flex-direction: row;
-  }
-  .pokemon-area p {
-    font-size: 0.8rem;
+    grid-template-columns: 1fr;
   }
 
   .move-button {
-    font-size: 0.85rem;
-    padding: 0.75rem;
-    width: 100%; /* 👉 가로 꽉 차게 */
-    box-sizing: border-box;
+    min-height: 105px;
+    padding: 0.56rem;
   }
 
-  .move-button .move-name {
-    font-size: 1rem;
-    text-align: center;
+  .move-name {
+    font-size: 0.89rem;
   }
 
-  .move-button .move-pp,
-  .move-button .move-power,
-  .move-button .move-accuracy,
-  .move-button .move-type {
-    font-size: 0.75rem;
-    text-align: center;
+  .move-pp,
+  .move-power,
+  .move-accuracy {
+    font-size: 0.7rem;
   }
 
-  .action-toggle {
-    display: flex;
-    justify-content: space-around;
-    margin-bottom: 0.75rem;
+  .battle-pad {
+    height: 180px;
+    padding: 0.75rem 0.85rem calc(0.75rem + env(safe-area-inset-bottom));
   }
-  
-  .action-toggle-btn {
-    padding: 0.6rem 1.2rem;
-    font-size: 1rem;
-    background-color: #6c9ffb;
-    color: white;
-    border: none;
-    border-radius: 8px;
-    cursor: pointer;
-    transition: background-color 0.2s;
+
+  .battle-layout--with-pad {
+    padding-bottom: 212px;
   }
-  
-  .action-toggle-btn:disabled {
-    background-color: #ccc;
-    cursor: not-allowed;
+
+  .pad-btn {
+    width: 49px;
+    height: 49px;
+    font-size: 1.04rem;
   }
-  
-  .action-toggle-btn:hover:not(:disabled) {
-    background-color: #1565c0;
+
+  .pad-center {
+    width: 44px;
+    height: 44px;
+  }
+
+  .select-screen {
+    margin: 0.8rem;
+  }
+
+  .watch-row {
+    flex-direction: column;
+    align-items: stretch;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -801,6 +801,92 @@ button {
   cursor: pointer;
 }
 
+.result-screen {
+  min-height: calc(100vh - 90px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.result-card {
+  width: min(560px, 100%);
+  border: 4px solid #7f6a2f;
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(255, 251, 238, 0.96), rgba(245, 232, 192, 0.94));
+  box-shadow: var(--ui-shadow);
+  padding: 1.2rem;
+  text-align: center;
+}
+
+.result-title {
+  margin: 0;
+  font-family: "VT323", monospace;
+  font-size: 2.8rem;
+}
+
+.result-subtitle {
+  margin: 0.4rem 0 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #8f2f25;
+}
+
+.result-save-box {
+  margin-top: 1rem;
+  border: 2px solid #8d773f;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.6);
+  padding: 0.7rem;
+  text-align: left;
+}
+
+.result-save-id,
+.result-save-status,
+.result-save-help,
+.result-save-error {
+  margin: 0.25rem 0;
+  font-size: 0.85rem;
+}
+
+.result-save-id {
+  font-family: "VT323", monospace;
+  font-size: 1.1rem;
+}
+
+.result-save-status {
+  color: #1e6a41;
+  font-weight: 700;
+}
+
+.result-save-help {
+  color: #5a4a25;
+}
+
+.result-save-error {
+  color: #9f2f24;
+  font-weight: 700;
+}
+
+.result-main-button {
+  margin-top: 1rem;
+  border: 2px solid #2d240f;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #4a8be8, #255fae);
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 700;
+  padding: 0.65rem 1rem;
+  cursor: pointer;
+}
+
+.result-flow-hint {
+  margin: 1rem 0 0;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #5b4a22;
+}
+
 .damage-effect {
   animation: shakeAndFlash 0.4s ease-in-out;
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -4,7 +4,7 @@ import { getAccessToken, getRefreshToken, removeAccessToken, setAccessToken } fr
 
 // API 기본 URL 설정
 const BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8090';
-
+console.log(BASE_URL);
 // 기본 요청 설정
 const defaultRequest = async <T>(
   path: string,


### PR DESCRIPTION
1. Netlify Functions(count, streak, history, leaderboard)와 공통 Mongo 유틸을 추가해 MongoDB Atlas에 전적/리더보드를 저장하도록 구성했습니다.\n2. 프론트 API를 함수 경로(/api/*) 기반으로 전환하고 playhistory, leaderboard 호출 로직을 게스트 playerId 기준으로 정리했습니다.\n3. Result 화면을 리디자인하여 저장 상태/오류/게스트 ID를 표시하도록 개선했고, MyPage에 게스트 기록 모드 안내 UI를 추가했습니다.\n4. netlify.toml 라우팅, mongodb 의존성, README 설정 가이드를 함께 갱신했습니다.