### PR TITLE
Remove VITE_API_URL exposure from frontend bundle

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -2,9 +2,9 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { getAccessToken, getRefreshToken, removeAccessToken, setAccessToken } from './storage';
 
 
-// API 기본 URL 설정
-const BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8090';
-console.log(BASE_URL);
+// Frontend should call same-origin API path so no secret env value is baked into the bundle.
+const API_PREFIX = '/api';
+
 // 기본 요청 설정
 const defaultRequest = async <T>(
   path: string,
@@ -13,7 +13,7 @@ const defaultRequest = async <T>(
   const accessToken = await getAccessToken();
   const refreshToken = await getRefreshToken();
 
-  const url = `${BASE_URL}/api${path}`;
+  const url = `${API_PREFIX}${path}`;
   const headers = {
     ...config.headers,
     Authorization: accessToken ? `Bearer ${accessToken}` : undefined,
@@ -36,9 +36,7 @@ const defaultRequest = async <T>(
     if (error.response.status === 401) {
       // 토큰 만료 처리
       try {
-        const refreshResponse = await axios.post(`${BASE_URL}/auth/refresh`, {
-          refreshToken,
-        });
+        const refreshResponse = await axios.post(`${API_PREFIX}/auth/refresh`, { refreshToken });
 
         if (refreshResponse.status === 200) {
           const newAccessToken = refreshResponse.data.accessToken;


### PR DESCRIPTION
1. 프론트 빌드 번들에서 VITE_API_URL 값이 주입되지 않도록 request 유틸의 환경변수 참조를 제거했습니다.\n2. API 호출 경로를 same-origin /api 기준으로 고정해 Netlify secrets scanning 차단 이슈를 해소했습니다.\n3. 토큰 갱신 경로도 동일하게 /api/auth/refresh를 사용하도록 정리했습니다.