### PR TITLE
Stabilize battle pad input and improve mobile battle view

### DIFF
--- a/src/components/ActionPanel.tsx
+++ b/src/components/ActionPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { BattlePokemon } from "../models/BattlePokemon";
 import SwapPanel from "./SwapPanel";
 import { useBattleStore } from "../Context/useBattleStore";
@@ -29,6 +29,7 @@ function ActionPanel({
   const [hintMode, setHintMode] = useState<boolean>(true);
   const [fightCursor, setFightCursor] = useState(0);
   const [switchCursor, setSwitchCursor] = useState(0);
+  const lastHandledPadCommandId = useRef(0);
   const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 900);
   const { turn, enemyTeam, activeEnemy } = useBattleStore.getState();
   const enemyTypes = enemyTeam[activeEnemy].base.types;
@@ -99,6 +100,10 @@ function ActionPanel({
 
   const handlePadAction = useCallback(
     (action: BattlePadAction) => {
+      if (isTurnProcessing || watchMode) {
+        return;
+      }
+
       if (action === "x") {
         setHintMode((prev) => !prev);
         return;
@@ -132,9 +137,6 @@ function ActionPanel({
       }
 
       if (action === "a") {
-        if (watchMode || isTurnProcessing) {
-          return;
-        }
         if (!currentTab) {
           setCurrentTab("fight");
           return;
@@ -160,8 +162,15 @@ function ActionPanel({
     if (!padCommand) {
       return;
     }
+    if (isTurnProcessing || watchMode) {
+      return;
+    }
+    if (padCommand.id === lastHandledPadCommandId.current) {
+      return;
+    }
+    lastHandledPadCommandId.current = padCommand.id;
     handlePadAction(padCommand.action);
-  }, [handlePadAction, padCommand]);
+  }, [handlePadAction, isTurnProcessing, padCommand, watchMode]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/src/components/Battle.tsx
+++ b/src/components/Battle.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useBattleStore } from "../Context/useBattleStore";
 import Result from "./Result";
 import { MoveInfo } from "../models/Move";
@@ -51,7 +51,8 @@ function Battle({ watchMode, redMode, randomMode, watchCount, watchDelay, setBat
   const [musicOn, setMusicOn] = useState(true);
   const navigate = useNavigate();
   const [redirected, setRedirected] = useState(false);
-  const slicedLogs = useMemo(() => logs.slice(-20), [logs]);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const toastTimerRef = useRef<NodeJS.Timeout | null>(null);
   useEffect(() => {
     const checkLastOne = () => {
       const aliveMy = myTeam.filter(p => p.currentHp > 0).length;
@@ -87,6 +88,29 @@ function Battle({ watchMode, redMode, randomMode, watchCount, watchDelay, setBat
       setRedirected(true);
     }
   }, [myTeam, enemyTeam, navigate]);
+
+  useEffect(() => {
+    if (!logs.length) {
+      return;
+    }
+
+    const latestLog = logs[logs.length - 1];
+    setToastMessage(latestLog);
+
+    if (toastTimerRef.current) {
+      clearTimeout(toastTimerRef.current);
+    }
+
+    toastTimerRef.current = setTimeout(() => {
+      setToastMessage(null);
+    }, 2000);
+
+    return () => {
+      if (toastTimerRef.current) {
+        clearTimeout(toastTimerRef.current);
+      }
+    };
+  }, [logs]);
 
   // ❗ 완전한 리다이렉트 후에는 렌더링하지 않음
   if (redirected || myTeam.length === 0 || enemyTeam.length === 0) {
@@ -144,9 +168,12 @@ function Battle({ watchMode, redMode, randomMode, watchCount, watchDelay, setBat
   const padCommandIdRef = useRef(0);
 
   const handlePadInput = useCallback((action: BattlePadAction) => {
+    if (watchMode || isTurnProcessing || isSwitchModalOpen) {
+      return;
+    }
     padCommandIdRef.current += 1;
     setPadCommand({ id: padCommandIdRef.current, action });
-  }, []);
+  }, [isSwitchModalOpen, isTurnProcessing, watchMode]);
   // useEffect(() => {
   //   timeLeftRef.current = timeLeft;
   //   console.log("💡 useEffect 타이머 리셋 트리거 확인", timeLeft);
@@ -431,6 +458,7 @@ function Battle({ watchMode, redMode, randomMode, watchCount, watchDelay, setBat
   return (
 
     <div className={`battle-layout ${watchMode ? "" : "battle-layout--with-pad"}`}>
+      {toastMessage && <div className="battle-toast">{toastMessage}</div>}
       <button
         onClick={() => {
           setMusicOn((prev) => {
@@ -530,9 +558,15 @@ function Battle({ watchMode, redMode, randomMode, watchCount, watchDelay, setBat
       <TurnBanner turn={turn} randomMode={randomMode} />
       <div className="main-area">
         <div className="pokemon_log">
-          <LogPanel logs={slicedLogs} />
-          <TimerBar timeLeft={timeLeft} />
-          <PokemonArea my={leftPokemon} enemy={rightPokemon} />
+          <div className="battle-timer-wrap">
+            <TimerBar timeLeft={timeLeft} />
+          </div>
+          <div className="battle-field-wrap">
+            <PokemonArea my={leftPokemon} enemy={rightPokemon} />
+          </div>
+          <div className="battle-log-wrap">
+            <LogPanel logs={logs} />
+          </div>
         </div>
 
         <div className="side-panel">

--- a/src/components/BattlePad.tsx
+++ b/src/components/BattlePad.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useRef } from "react";
 
 export type BattlePadAction = "up" | "down" | "left" | "right" | "x" | "y" | "a" | "b";
 
@@ -8,11 +8,18 @@ type BattlePadProps = {
 };
 
 function BattlePad({ onInput, disabled = false }: BattlePadProps) {
+  const lastPressAtRef = useRef(0);
+
   const startPress = useCallback(
     (action: BattlePadAction) => {
       if (disabled) {
         return;
       }
+      const now = Date.now();
+      if (now - lastPressAtRef.current < 90) {
+        return;
+      }
+      lastPressAtRef.current = now;
       onInput(action);
     },
     [disabled, onInput]
@@ -54,18 +61,18 @@ function BattlePad({ onInput, disabled = false }: BattlePadProps) {
 
       <div className="battle-pad-right">
         <button
-          className="pad-btn face-btn y-btn"
-          type="button"
-          onPointerDown={() => startPress("y")}
-        >
-          Y
-        </button>
-        <button
           className="pad-btn face-btn x-btn"
           type="button"
           onPointerDown={() => startPress("x")}
         >
           X
+        </button>
+        <button
+          className="pad-btn face-btn y-btn"
+          type="button"
+          onPointerDown={() => startPress("y")}
+        >
+          Y
         </button>
         <button
           className="pad-btn face-btn a-btn"

--- a/src/components/PokemonSelect.tsx
+++ b/src/components/PokemonSelect.tsx
@@ -226,19 +226,19 @@ function PokemonSelect({ onSelect }: Props) {
           </button>
         </div>
 
-        <div className="watch-mode">
+        {/* <div className="watch-mode">
           <h3>관전 모드</h3>
           <div className="watch-row">
-            {/* <div style={{ flex: 0.3 }}> TODO: 관전횟수는 나중에 추가
-      <h5>관전 횟수</h5>
-      <input
-        type="number"
-        min={1}
-        value={watchCount}
-        onChange={(e) => setWatchCount(parseInt(e.target.value))}
-        style={{ marginRight: "0.5rem", padding: "0.25rem 0.5rem" }}
-      />
-    </div> */}
+            <div style={{ flex: 0.3 }}> TODO: 관전횟수는 나중에 추가
+              <h5>관전 횟수</h5>
+              <input
+                type="number"
+                min={1}
+                value={watchCount}
+                onChange={(e) => setWatchCount(parseInt(e.target.value))}
+                style={{ marginRight: "0.5rem", padding: "0.25rem 0.5rem" }}
+              />
+            </div>
             <div className="watch-input-wrap">
               <h5>관전 딜레이 타임</h5>
               <input
@@ -257,7 +257,7 @@ function PokemonSelect({ onSelect }: Props) {
               관전 시작
             </button>
           </div>
-        </div>
+        </div> */}
 
       </div>
       {showDetailModal && selectedPokemonInfo && (

--- a/src/index.css
+++ b/src/index.css
@@ -126,6 +126,18 @@ button {
   gap: 0.7rem;
 }
 
+.battle-timer-wrap {
+  order: 1;
+}
+
+.battle-field-wrap {
+  order: 2;
+}
+
+.battle-log-wrap {
+  order: 3;
+}
+
 .timer-bar-shell {
   width: 100%;
   height: 10px;
@@ -491,6 +503,24 @@ button {
   margin-top: 0;
 }
 
+.battle-toast {
+  position: fixed;
+  left: 50%;
+  top: 96px;
+  transform: translateX(-50%);
+  z-index: 3500;
+  max-width: min(680px, calc(100vw - 2rem));
+  border: 2px solid #2a2211;
+  border-radius: 10px;
+  background: rgba(27, 42, 84, 0.95);
+  color: #fff;
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1.4;
+  padding: 0.45rem 0.7rem;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.24);
+}
+
 .battle-pad {
   position: fixed;
   left: 0;
@@ -546,8 +576,8 @@ button {
   place-items: center;
 }
 
-.y-btn { grid-column: 2; grid-row: 1; }
-.x-btn { grid-column: 1; grid-row: 2; }
+.x-btn { grid-column: 2; grid-row: 1; }
+.y-btn { grid-column: 1; grid-row: 2; }
 .a-btn { grid-column: 3; grid-row: 2; }
 .b-btn { grid-column: 2; grid-row: 3; }
 
@@ -953,8 +983,29 @@ button {
     font-size: 1.35rem;
   }
 
+  .main-area {
+    gap: 0.6rem;
+  }
+
   .pokemon-area {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .pokemon-card {
+    min-height: 225px;
+    padding: 0.55rem;
+  }
+
+  .pokemon-card h5 {
+    font-size: 0.85rem;
+  }
+
+  .pokemon-card p {
+    font-size: 0.77rem;
+  }
+
+  .battle-log-wrap .log-panel {
+    max-height: 150px;
   }
 
   .move-button {
@@ -994,6 +1045,11 @@ button {
 
   .select-screen {
     margin: 0.8rem;
+  }
+
+  .battle-toast {
+    top: 80px;
+    font-size: 0.75rem;
   }
 
   .watch-row {

--- a/src/utils/battleLogics/applyAfterDamage.ts
+++ b/src/utils/battleLogics/applyAfterDamage.ts
@@ -48,7 +48,7 @@ async function applyPanicUturn(side: "my" | "enemy", attacker: BattlePokemon, de
     let switchPromise: Promise<void> | null = null;
 
     if (watchMode || side === "enemy") {
-      console.log("👀 관전 모드 또는 AI: 위기회피 자동 교체");
+      console.log("👀 AI: 위기회피 자동 교체");
       const switchIndex = getBestSwitchIndex(side);
       switchPromise = new Promise<void>(async (resolve) => {
         await switchPokemon(side, switchIndex);
@@ -364,6 +364,7 @@ export async function applyDefensiveAbilityEffectAfterMultiDamage(side: "my" | "
             updatePokemon(opponentSide, activeOpponent, (defender) => changeRank(defender, 'defense', 1));
           }
         }
+        break;
     }
   }
   )
@@ -415,6 +416,7 @@ async function applyDefensiveAbilityEffectAfterDamage(side: "my" | "enemy", atta
             updatePokemon(opponentSide, activeOpponent, (defender) => changeRank(defender, 'defense', 1));
           }
         }
+        break;
       case "status_change":
         if (ability.name === '불꽃몸' && usedMove.isTouch) {
           if (Math.random() < 0.3) {
@@ -445,6 +447,7 @@ async function applyDefensiveAbilityEffectAfterDamage(side: "my" | "enemy", atta
             updatePokemon(side, activeMine, (prev) => addStatus(prev, '사슬묶기', side));
           }
         }
+        break;
       default:
         return;
     }
@@ -470,6 +473,7 @@ async function applyOffensiveAbilityEffectAfrerDamage(side: "my" | "enemy", atta
             updatePokemon(opponentSide, activeOpponent, (prev) => addStatus(prev, '독', opponentSide));
           }
         }
+        break;
       default:
         return;
     }


### PR DESCRIPTION
1. padCommand 중복 처리 문제를 막기 위해 명령 ID 단위 1회 처리 가드를 추가해 입력 폭주를 해결했습니다.\n2. BattlePad 자동 반복 입력을 제거하고 입력 디바운스를 넣어 A/십자키 연타 오작동을 줄였습니다.\n3. 모바일 배틀 레이아웃을 개선해 포켓몬 영역을 좌우 배치로 유지하고 로그 패널을 하단으로 이동시켰습니다.\n4. 새 로그를 2초간 표시하는 토스트 팝업을 추가해 로그 가시성을 높였습니다.