### PR TITLE
Add player ID linking for record recovery

### DIFF
--- a/netlify/functions/player.js
+++ b/netlify/functions/player.js
@@ -1,0 +1,39 @@
+const { getDb } = require("./_lib/mongo");
+const { json } = require("./_lib/http");
+const { normalizePlayerId } = require("./_lib/player");
+
+/**
+ * Return one player's stats by playerId.
+ */
+exports.handler = async (event) => {
+  if (event.httpMethod !== "GET") {
+    return json(405, { message: "Method not allowed" });
+  }
+
+  const playerId = normalizePlayerId(event.queryStringParameters?.playerId || "");
+  if (!playerId) {
+    return json(400, { message: "playerId is required" });
+  }
+
+  try {
+    const db = await getDb();
+    const players = db.collection("players");
+    const player = await players.findOne({ playerId });
+
+    if (!player) {
+      return json(404, { message: "Player not found" });
+    }
+
+    return json(200, {
+      playerId: player.playerId,
+      username: player.displayName || `Trainer-${String(player.playerId || "").slice(-6).toUpperCase()}`,
+      winCount: player.winCount || 0,
+      loseCount: player.loseCount || 0,
+      winStreak: player.winStreak || 0,
+      bestWinStreak: player.bestWinStreak || 0,
+    });
+  } catch (error) {
+    console.error("[player] failed", error);
+    return json(500, { message: "Failed to load player" });
+  }
+};

--- a/public/_redirects
+++ b/public/_redirects
@@ -2,4 +2,5 @@
 /api/streak /.netlify/functions/streak 200
 /api/history /.netlify/functions/history 200
 /api/leaderboard /.netlify/functions/leaderboard 200
+/api/player /.netlify/functions/player 200
 /* /index.html 200

--- a/readme.md
+++ b/readme.md
@@ -23,3 +23,4 @@
   - `/api/streak` -> `/.netlify/functions/streak`
   - `/api/history` -> `/.netlify/functions/history`
   - `/api/leaderboard` -> `/.netlify/functions/leaderboard`
+  - `/api/player` -> `/.netlify/functions/player`

--- a/src/api/playhistory.ts
+++ b/src/api/playhistory.ts
@@ -8,6 +8,10 @@ export interface GameResult {
   bestWinStreak: number;
 }
 
+export interface PlayerRecord extends GameResult {
+  username: string;
+}
+
 export class GameError extends Error {
   constructor(message: string, public status?: number) {
     super(message);
@@ -29,6 +33,19 @@ export function getOrCreateGuestPlayerId(): string {
   const generated = `guest_${crypto.randomUUID()}`;
   localStorage.setItem(GUEST_PLAYER_KEY, generated);
   return generated;
+}
+
+/**
+ * Persist a user-provided player id for record linking across sessions/devices.
+ */
+export function setGuestPlayerId(rawPlayerId: string): string {
+  const normalized = rawPlayerId.trim();
+  if (!normalized) {
+    throw new GameError("ID를 입력해주세요.");
+  }
+
+  localStorage.setItem(GUEST_PLAYER_KEY, normalized);
+  return normalized;
 }
 
 /**
@@ -79,5 +96,30 @@ export async function addPlayHistory(result: "win" | "lose", mode: "normal" | "r
     });
   } catch (error: any) {
     throw new GameError("게임 히스토리 저장에 실패했습니다.", error.response?.status);
+  }
+}
+
+/**
+ * Load one player's aggregate record by id.
+ */
+export async function loadPlayerRecord(playerId?: string): Promise<PlayerRecord> {
+  const targetId = (playerId ?? getOrCreateGuestPlayerId()).trim();
+  if (!targetId) {
+    throw new GameError("ID를 입력해주세요.");
+  }
+
+  try {
+    const response = await axios.get<PlayerRecord>("/api/player", {
+      params: { playerId: targetId },
+    });
+    return response.data;
+  } catch (error: any) {
+    if (error.response?.status === 404) {
+      throw new GameError("해당 ID의 기록을 찾을 수 없습니다.", 404);
+    }
+    if (error.response?.status === 400) {
+      throw new GameError("ID 형식이 올바르지 않습니다.", 400);
+    }
+    throw new GameError("기록 조회에 실패했습니다.", error.response?.status);
   }
 }

--- a/src/components/MyPage.css
+++ b/src/components/MyPage.css
@@ -15,6 +15,37 @@
   gap: 0.8rem;
 }
 
+.id-link-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.8rem;
+}
+
+.id-link-form input {
+  flex: 1;
+  border: 2px solid #aa9258;
+  border-radius: 8px;
+  padding: 0.55rem 0.6rem;
+  font-size: 0.86rem;
+}
+
+.id-link-form button {
+  border: 2px solid #2d240f;
+  border-radius: 10px;
+  color: #fff;
+  font-size: 0.84rem;
+  font-weight: 700;
+  padding: 0.55rem 0.8rem;
+  background: linear-gradient(180deg, #4a8be8, #255fae);
+  cursor: pointer;
+}
+
+.id-link-form button:disabled {
+  background: #9c9a93;
+  border-color: #7f7c75;
+  cursor: not-allowed;
+}
+
 .guest-mode-box {
   border: 2px dashed #8b7538;
   border-radius: 10px;
@@ -148,6 +179,17 @@
   font-family: "VT323", monospace;
   font-size: 2rem;
   color: #264d8a;
+  word-break: break-word;
+}
+
+.empty-record-box {
+  border: 2px dashed #8b7538;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.65);
+  padding: 0.7rem;
+  margin-bottom: 0.9rem;
+  font-size: 0.86rem;
+  color: #5f4c24;
 }
 
 .error-message {
@@ -166,5 +208,9 @@
   .auth-container,
   .mypage-container {
     margin: 0.8rem;
+  }
+
+  .id-link-form {
+    flex-direction: column;
   }
 }

--- a/src/components/MyPage.tsx
+++ b/src/components/MyPage.tsx
@@ -1,20 +1,111 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { getOrCreateGuestPlayerId } from "../api/playhistory";
+import { GameError, getOrCreateGuestPlayerId, loadPlayerRecord, PlayerRecord, setGuestPlayerId } from "../api/playhistory";
 import "./MyPage.css";
 
 function MyPage() {
   const navigate = useNavigate();
-  const guestId = useMemo(() => getOrCreateGuestPlayerId(), []);
+  const [currentId, setCurrentId] = useState("");
+  const [idInput, setIdInput] = useState("");
+  const [record, setRecord] = useState<PlayerRecord | null>(null);
+  const [message, setMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const init = async () => {
+      const playerId = getOrCreateGuestPlayerId();
+      setCurrentId(playerId);
+      setIdInput(playerId);
+
+      try {
+        const data = await loadPlayerRecord(playerId);
+        setRecord(data);
+      } catch (error) {
+        setRecord(null);
+      }
+    };
+
+    init();
+  }, []);
+
+  const handleLinkId = async () => {
+    setMessage("");
+    setIsLoading(true);
+
+    try {
+      const normalizedId = setGuestPlayerId(idInput);
+      const data = await loadPlayerRecord(normalizedId);
+      setCurrentId(normalizedId);
+      setRecord(data);
+      setMessage("ID 연결 완료! 해당 기록으로 이어서 플레이합니다.");
+    } catch (error) {
+      if (error instanceof GameError) {
+        setMessage(error.message);
+      } else {
+        setMessage("ID 연결에 실패했습니다.");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const winRate = record && record.winCount + record.loseCount > 0
+    ? Math.round((record.winCount / (record.winCount + record.loseCount)) * 100)
+    : 0;
 
   return (
     <div className="auth-container">
       <div className="guest-mode-box">
-        <h3>게스트 기록 모드</h3>
-        <p>현재 Yakemon은 게스트 ID 기반으로 전적을 저장합니다.</p>
-        <p>로그인/회원가입 API는 비활성화되어 있으며 요청도 보내지 않습니다.</p>
-        <p className="guest-id">ID: {guestId.slice(-12)}</p>
+        <h3>게스트 ID 연결</h3>
+        <p>다른 기기의 ID를 입력하면 그 기록으로 이어받을 수 있습니다.</p>
+        <p className="guest-id">현재 ID: {currentId || "로딩 중..."}</p>
       </div>
+
+      <div className="id-link-form">
+        <input
+          value={idInput}
+          onChange={(event) => setIdInput(event.target.value)}
+          placeholder="guest_xxxxx 형태의 ID 입력"
+        />
+        <button onClick={handleLinkId} disabled={isLoading}>
+          {isLoading ? "연결 중..." : "ID 연결"}
+        </button>
+      </div>
+
+      {message && <div className="error-message">{message}</div>}
+
+      {record ? (
+        <div className="stats-container">
+          <div className="stat-box">
+            <h3>이름</h3>
+            <p>{record.username}</p>
+          </div>
+          <div className="stat-box">
+            <h3>승리</h3>
+            <p>{record.winCount}</p>
+          </div>
+          <div className="stat-box">
+            <h3>패배</h3>
+            <p>{record.loseCount}</p>
+          </div>
+          <div className="stat-box">
+            <h3>현재 연승</h3>
+            <p>{record.winStreak}</p>
+          </div>
+          <div className="stat-box">
+            <h3>최고 연승</h3>
+            <p>{record.bestWinStreak}</p>
+          </div>
+          <div className="stat-box">
+            <h3>승률</h3>
+            <p>{winRate}%</p>
+          </div>
+        </div>
+      ) : (
+        <div className="empty-record-box">
+          아직 이 ID에 저장된 기록이 없습니다. 배틀을 1회 진행한 뒤 다시 확인하세요.
+        </div>
+      )}
 
       <div className="auth-buttons">
         <button onClick={() => navigate("/leaderboard")}>리더보드 보기</button>


### PR DESCRIPTION
1. /api/player 조회 함수를 추가해 특정 playerId의 전적(승/패/연승/최고연승)을 불러올 수 있게 했습니다.\n2. MyPage에 ID 입력/연결 UI를 구현해 사용자들이 기존 ID를 입력해 기록을 이어받을 수 있도록 했습니다.\n3. playhistory 유틸에 setGuestPlayerId, loadPlayerRecord를 추가해 ID 교체와 기록 조회 흐름을 정리했습니다.\n4. _redirects와 README에 /api/player 경로를 추가해 배포 라우팅/문서를 함께 업데이트했습니다.